### PR TITLE
Improve gameplay start, fullscreen mode, BMP face upload, and modern menu

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -28,6 +28,11 @@ faceInput.addEventListener('change', function() {
 startBtn.addEventListener('click', () => {
   menu.style.display = 'none';
   canvas.style.display = 'block';
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  if (canvas.requestFullscreen) {
+    canvas.requestFullscreen();
+  }
   const diff = difficulties[difficultySelect.value];
   initGame(diff);
   requestAnimationFrame(loop);
@@ -37,32 +42,39 @@ const gravity = 0.5;
 let platformWidth = 90;
 let speed = 2;
 
-let player, platforms, keys, gameOver;
+let player, platforms, keys, gameOver, gameStarted;
 
 function initGame(diff) {
   platformWidth = diff.platformWidth;
   speed = diff.speed;
   player = {
     x: canvas.width / 2 - 20,
-    y: canvas.height - 60,
+    y: canvas.height - 80,
     width: 40,
     height: 60,
     vx: 0,
     vy: 0,
-    onGround: false
+    onGround: true
   };
   platforms = [];
+  platforms.push({
+    x: 0,
+    y: canvas.height - 20,
+    width: canvas.width,
+    height: 10
+  });
   const num = 6;
-  for (let i = 0; i < num; i++) {
+  for (let i = 1; i < num; i++) {
     platforms.push({
       x: Math.random() * (canvas.width - platformWidth),
-      y: canvas.height - i * 100,
+      y: canvas.height - 20 - i * 100,
       width: platformWidth,
       height: 10
     });
   }
   keys = {};
   gameOver = false;
+  gameStarted = false;
 }
 
 document.addEventListener('keydown', e => {
@@ -81,6 +93,7 @@ function update() {
   if (keys['Space'] && player.onGround) {
     player.vy = -10;
     player.onGround = false;
+    if (!gameStarted) gameStarted = true;
   }
 
   player.vy += gravity;
@@ -104,18 +117,22 @@ function update() {
       player.vy = 0;
       player.onGround = true;
     }
-    plat.y += speed;
+    if (gameStarted) {
+      plat.y += speed;
+    }
   }
 
   // spawn new platforms
-  while (platforms.length && platforms[0].y > canvas.height) {
-    platforms.shift();
-    platforms.push({
-      x: Math.random() * (canvas.width - platformWidth),
-      y: -10,
-      width: platformWidth,
-      height: 10
-    });
+  if (gameStarted) {
+    while (platforms.length && platforms[0].y > canvas.height) {
+      platforms.shift();
+      platforms.push({
+        x: Math.random() * (canvas.width - platformWidth),
+        y: -10,
+        width: platformWidth,
+        height: 10
+      });
+    }
   }
 
   if (player.y > canvas.height) {

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -8,7 +8,7 @@
 <body>
   <div id="menu">
     <h1>Icy Tower Clone</h1>
-    <label>Wgraj twarz (jpg): <input type="file" id="faceInput" accept="image/jpeg" /></label>
+    <label>Wgraj twarz (bmp): <input type="file" id="faceInput" accept="image/bmp,image/x-ms-bmp" /></label>
     <div>
       <label>Poziom trudności:
         <select id="difficulty">
@@ -20,7 +20,7 @@
     </div>
     <button id="startBtn">Start</button>
   </div>
-  <canvas id="game" width="400" height="600" style="display:none;"></canvas>
+  <canvas id="game" style="display:none;"></canvas>
   <script src="game.js"></script>
 </body>
 </html>

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -1,12 +1,40 @@
 body {
   font-family: Arial, sans-serif;
-  background: #eef;
+  background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
   text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
 }
+
 #menu {
-  margin-top: 50px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 40px;
+  border-radius: 10px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
 }
+
+#startBtn {
+  background: #4caf50;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1rem;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-top: 15px;
+}
+
+#startBtn:hover {
+  background: #45a049;
+}
+
 #game {
   background: #fff;
-  border: 1px solid #000;
+  border: none;
+  display: block;
+  width: 100vw;
+  height: 100vh;
 }


### PR DESCRIPTION
## Summary
- Ensure the character starts on a base platform and scrolling begins only after the first jump
- Allow BMP face uploads and make the canvas launch fullscreen
- Refresh the menu with a colorful, modern style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990a8296408320afb48979d29ba03f