### PR TITLE
Allow PNG uploads for face image

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -8,7 +8,7 @@
 <body>
   <div id="menu">
     <h1>Icy Tower Clone</h1>
-    <label>Wgraj twarz (bmp): <input type="file" id="faceInput" accept="image/bmp,image/x-ms-bmp" /></label>
+    <label>Wgraj twarz (png): <input type="file" id="faceInput" accept="image/png" /></label>
     <div>
       <label>Poziom trudności:
         <select id="difficulty">


### PR DESCRIPTION
## Summary
- Update Icy Tower clone to accept PNG face images instead of BMP.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990c47fce883209e424219c1bada54