### PR TITLE
Extend jump mechanics and refine game over flow

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -25,7 +25,9 @@
     <p id="finalScore"></p>
     <h2>Tabela wyników:</h2>
     <pre id="scoreTable"></pre>
-    <a id="downloadScores" download="scores.txt">Pobierz wyniki</a>
+    <input id="nickname" placeholder="Twój nick" />
+    <button id="saveScoreBtn">Zapisz wynik</button>
+    <button id="newGameBtn">Nowa Gra</button>
   </div>
   <script src="game.js"></script>
 </body>

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -54,7 +54,37 @@ body {
   font-size: 24px;
 }
 
-#downloadScores {
-  margin-top: 20px;
+#nickname {
+  margin-top: 15px;
+  padding: 8px;
+  border: none;
+  border-radius: 5px;
+  font-size: 1rem;
+}
+
+#saveScoreBtn,
+#newGameBtn {
   color: #fff;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1rem;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-top: 15px;
+}
+
+#saveScoreBtn {
+  background: #4caf50;
+}
+
+#saveScoreBtn:hover {
+  background: #45a049;
+}
+
+#newGameBtn {
+  background: #2196f3;
+}
+
+#newGameBtn:hover {
+  background: #1976d2;
 }


### PR DESCRIPTION
## Summary
- lengthen jump height and allow mid-air steering
- accelerate camera to keep player centered during jumps
- add nickname entry with automatic score save and styled new game button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689912e98b1883209f5c968072e8500d