### PR TITLE
Extend jump mechanics and refine game over flow

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -30,9 +30,6 @@ startBtn.addEventListener('click', () => {
   canvas.style.display = 'block';
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
-  if (canvas.requestFullscreen) {
-    canvas.requestFullscreen();
-  }
   const diff = difficulties[difficultySelect.value];
   initGame(diff);
   requestAnimationFrame(loop);
@@ -45,6 +42,7 @@ let speed = 2;
 let player, platforms, keys, gameOver, gameStarted, score;
 let gameOverDisplayed = false;
 let gameAreaWidth, gameAreaX;
+let platformSpacing, nextPlatformId, comboActive;
 
 function initGame(diff) {
   platformWidth = diff.platformWidth;
@@ -58,24 +56,30 @@ function initGame(diff) {
     height: 60,
     vx: 0,
     vy: 0,
-    onGround: true
+    onGround: true,
+    lastPlatformId: 0
   };
   platforms = [];
+  const num = Math.ceil(canvas.height / 100);
+  platformSpacing = (canvas.height - 20) / (num - 1);
   platforms.push({
     x: gameAreaX,
     y: canvas.height - 20,
     width: gameAreaWidth,
-    height: 10
+    height: 10,
+    id: 0
   });
-  const num = 6;
   for (let i = 1; i < num; i++) {
     platforms.push({
       x: gameAreaX + Math.random() * (gameAreaWidth - platformWidth),
-      y: canvas.height - 20 - i * 100,
+      y: canvas.height - 20 - i * platformSpacing,
       width: platformWidth,
-      height: 10
+      height: 10,
+      id: i
     });
   }
+  nextPlatformId = num;
+  comboActive = false;
   keys = {};
   gameOver = false;
   gameStarted = false;
@@ -92,12 +96,12 @@ document.addEventListener('keyup', e => {
 });
 
 function update() {
-  if (keys['ArrowLeft']) player.vx = -3;
-  else if (keys['ArrowRight']) player.vx = 3;
+  if (keys['ArrowLeft']) player.vx = -4;
+  else if (keys['ArrowRight']) player.vx = 4;
   else player.vx = 0;
 
   if (keys['Space'] && player.onGround) {
-    player.vy = -10;
+    player.vy = -20;
     player.onGround = false;
     if (!gameStarted) gameStarted = true;
   }
@@ -124,8 +128,23 @@ function update() {
       player.y = plat.y - player.height;
       player.vy = 0;
       player.onGround = true;
+      const jumped = plat.id - player.lastPlatformId;
+      comboActive = jumped >= 3;
+      const multiplier = comboActive ? 2 : 1;
+      score += jumped * multiplier;
+      player.lastPlatformId = plat.id;
     }
-    if (gameStarted) {
+  }
+
+  if (gameStarted) {
+    if (player.y < canvas.height / 2) {
+      const diffY = canvas.height / 2 - player.y;
+      player.y = canvas.height / 2;
+      for (let plat of platforms) {
+        plat.y += diffY;
+      }
+    }
+    for (let plat of platforms) {
       plat.y += speed;
     }
   }
@@ -134,14 +153,14 @@ function update() {
   if (gameStarted) {
     while (platforms.length && platforms[0].y > canvas.height) {
       platforms.shift();
-      const lastY = platforms[platforms.length - 1].y;
+      const last = platforms[platforms.length - 1];
       platforms.push({
         x: gameAreaX + Math.random() * (gameAreaWidth - platformWidth),
-        y: lastY - 100,
+        y: last.y - platformSpacing,
         width: platformWidth,
-        height: 10
+        height: 10,
+        id: nextPlatformId++
       });
-      score++;
     }
   }
 
@@ -180,26 +199,48 @@ function draw() {
   ctx.font = '24px Arial';
   ctx.textAlign = 'right';
   ctx.fillText(`Score: ${score}`, canvas.width - 20, 30);
+  if (comboActive) {
+    ctx.fillText('Combo x2!', canvas.width - 20, 60);
+  }
 }
 
 function showGameOverScreen() {
   const gameOverDiv = document.getElementById('gameOver');
   const finalScore = document.getElementById('finalScore');
   const scoreTable = document.getElementById('scoreTable');
-  const downloadLink = document.getElementById('downloadScores');
 
   finalScore.textContent = `Gratulacje! Twój wynik: ${score}`;
   const scores = JSON.parse(localStorage.getItem('scores') || '[]');
-  scores.push(score);
-  scores.sort((a, b) => b - a);
-  localStorage.setItem('scores', JSON.stringify(scores));
   scoreTable.textContent = scores
-    .map((s, i) => `${i + 1}. ${s}`)
+    .map((s, i) => `${i + 1}. ${s.name}: ${s.score}`)
     .join('\n');
-  const blob = new Blob([scoreTable.textContent], { type: 'text/plain' });
-  downloadLink.href = URL.createObjectURL(blob);
   gameOverDiv.style.display = 'flex';
 }
+
+const saveScoreBtn = document.getElementById('saveScoreBtn');
+saveScoreBtn.addEventListener('click', () => {
+  const nicknameInput = document.getElementById('nickname');
+  const scoreTable = document.getElementById('scoreTable');
+  const nick = nicknameInput.value.trim() || 'Anon';
+  const scores = JSON.parse(localStorage.getItem('scores') || '[]');
+  scores.push({ name: nick, score });
+  scores.sort((a, b) => b.score - a.score);
+  localStorage.setItem('scores', JSON.stringify(scores));
+  scoreTable.textContent = scores
+    .map((s, i) => `${i + 1}. ${s.name}: ${s.score}`)
+    .join('\n');
+  saveScoreBtn.disabled = true;
+});
+
+const newGameBtn = document.getElementById('newGameBtn');
+newGameBtn.addEventListener('click', () => {
+  const gameOverDiv = document.getElementById('gameOver');
+  gameOverDiv.style.display = 'none';
+  menu.style.display = 'block';
+  canvas.style.display = 'none';
+  document.getElementById('nickname').value = '';
+  saveScoreBtn.disabled = false;
+});
 
 function loop() {
   if (gameOver) {

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -25,7 +25,9 @@
     <p id="finalScore"></p>
     <h2>Tabela wyników:</h2>
     <pre id="scoreTable"></pre>
-    <a id="downloadScores" download="scores.txt">Pobierz wyniki</a>
+    <input id="nickname" placeholder="Twój nick" />
+    <button id="saveScoreBtn">Zapisz wynik</button>
+    <button id="newGameBtn">Nowa Gra</button>
   </div>
   <script src="game.js"></script>
 </body>

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -54,7 +54,37 @@ body {
   font-size: 24px;
 }
 
-#downloadScores {
-  margin-top: 20px;
+#nickname {
+  margin-top: 15px;
+  padding: 8px;
+  border: none;
+  border-radius: 5px;
+  font-size: 1rem;
+}
+
+#saveScoreBtn,
+#newGameBtn {
   color: #fff;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1rem;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-top: 15px;
+}
+
+#saveScoreBtn {
+  background: #4caf50;
+}
+
+#saveScoreBtn:hover {
+  background: #45a049;
+}
+
+#newGameBtn {
+  background: #2196f3;
+}
+
+#newGameBtn:hover {
+  background: #1976d2;
 }


### PR DESCRIPTION
## Summary
- spread platforms to cover the entire vertical viewport so every tile is visible
- add combo scoring: skipping ≥3 tiles doubles the points and shows a combo indicator
- store scores with nickname locally without prompting file download

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689912e98b1883209f5c968072e8500d