### PR TITLE
Fix game initialization by closing drawStar function

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -254,6 +254,7 @@ function drawStar(x, y, r) {
   }
   ctx.closePath();
   ctx.fill();
+}
 
 function showGameOverScreen() {
   const gameOverDiv = document.getElementById('gameOver');


### PR DESCRIPTION
## Summary
- Close the `drawStar` helper in game.js so the script parses and the start button works

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68991f10a0d08320b27321b124264322