### PR TITLE
Handle invalid score data

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -262,7 +262,12 @@ function showGameOverScreen() {
   const scoreTable = document.getElementById('scoreTable');
 
   finalScore.textContent = `Gratulacje! Twój wynik: ${score}`;
-  const scores = JSON.parse(localStorage.getItem('scores') || '[]');
+  let scores;
+  try {
+    scores = JSON.parse(localStorage.getItem('scores')) || [];
+  } catch (e) {
+    scores = [];
+  }
   scoreTable.textContent = scores
     .map((s, i) => `${i + 1}. ${s.name}: ${s.score}`)
     .join('\n');
@@ -274,7 +279,12 @@ saveScoreBtn.addEventListener('click', () => {
   const nicknameInput = document.getElementById('nickname');
   const scoreTable = document.getElementById('scoreTable');
   const nick = nicknameInput.value.trim() || 'Anon';
-  const scores = JSON.parse(localStorage.getItem('scores') || '[]');
+  let scores;
+  try {
+    scores = JSON.parse(localStorage.getItem('scores')) || [];
+  } catch (e) {
+    scores = [];
+  }
   scores.push({ name: nick, score });
   scores.sort((a, b) => b.score - a.score);
   localStorage.setItem('scores', JSON.stringify(scores));


### PR DESCRIPTION
## Summary
- handle malformed score data in localStorage when showing or saving scores

## Testing
- `node --check icy-tower/game.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68991ff4299883209d527d8a6a14b673