### PR TITLE
feat: boost jumps with high combos

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -104,7 +104,11 @@ function update() {
   else player.vx = 0;
 
   if (keys['Space'] && player.onGround) {
-    player.vy = -20;
+    let jumpPower = -20;
+    if (comboMultiplier >= 4) {
+      jumpPower *= comboMultiplier / 2;
+    }
+    player.vy = jumpPower;
     player.onGround = false;
     if (!gameStarted) gameStarted = true;
   }
@@ -132,13 +136,19 @@ function update() {
       player.vy = 0;
       player.onGround = true;
       const jumped = plat.id - player.lastPlatformId;
-      if (jumped >= 3) {
-        comboHits++;
-        if (comboHits >= comboMultiplier) {
-          comboMultiplier *= 2;
-          comboHits = 0;
+      const highestId = platforms[platforms.length - 1].id;
+      const isHighest = plat.id === highestId;
+      if (isHighest) {
+        if (jumped >= 3) {
+          comboHits++;
+          if (comboHits >= comboMultiplier) {
+            comboMultiplier *= 2;
+            comboHits = 0;
+          }
+          score += jumped * comboMultiplier;
+        } else {
+          score += jumped;
         }
-        score += jumped * comboMultiplier;
       } else {
         score += jumped;
         comboMultiplier = 1;


### PR DESCRIPTION
## Summary
- Scale jump height with combo values of x4 or greater
- Maintain combo only when landing on the highest platform

## Testing
- `node --check icy-tower/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68992539dac48320928a102449eeb661