### PR TITLE
fix: restore combo threshold and scale with jump boost

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -104,7 +104,8 @@ function update() {
   else player.vx = 0;
 
   if (keys['Space'] && player.onGround) {
-    player.vy = -20;
+    const heightBoost = comboMultiplier >= 4 ? comboMultiplier / 2 : 1;
+    player.vy = -20 * heightBoost;
     player.onGround = false;
     if (!gameStarted) gameStarted = true;
   }
@@ -132,13 +133,21 @@ function update() {
       player.vy = 0;
       player.onGround = true;
       const jumped = plat.id - player.lastPlatformId;
-      if (jumped >= 3) {
-        comboHits++;
-        if (comboHits >= comboMultiplier) {
-          comboMultiplier *= 2;
-          comboHits = 0;
+      const highestId = platforms[platforms.length - 1].id;
+      const isHighest = plat.id === highestId;
+      if (isHighest) {
+        const heightBoost = comboMultiplier >= 4 ? comboMultiplier / 2 : 1;
+        const needed = 4 * heightBoost;
+        if (jumped >= needed) {
+          comboHits++;
+          if (comboHits >= comboMultiplier) {
+            comboMultiplier *= 2;
+            comboHits = 0;
+          }
+          score += jumped * comboMultiplier;
+        } else {
+          score += jumped;
         }
-        score += jumped * comboMultiplier;
       } else {
         score += jumped;
         comboMultiplier = 1;


### PR DESCRIPTION
## Summary
- Scale character jump and combo threshold using a shared height boost
- Require skipping more platforms for higher combos to register

## Testing
- `node --check icy-tower/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68992539dac48320928a102449eeb661