### PR TITLE
Restore prior combo logic with jump boost

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -133,21 +133,13 @@ function update() {
       player.vy = 0;
       player.onGround = true;
       const jumped = plat.id - player.lastPlatformId;
-      const highestId = platforms[platforms.length - 1].id;
-      const isHighest = plat.id === highestId;
-      if (isHighest) {
-        const heightBoost = comboMultiplier >= 4 ? comboMultiplier / 2 : 1;
-        const needed = 4 * heightBoost;
-        if (jumped >= needed) {
-          comboHits++;
-          if (comboHits >= comboMultiplier) {
-            comboMultiplier *= 2;
-            comboHits = 0;
-          }
-          score += jumped * comboMultiplier;
-        } else {
-          score += jumped;
+      if (jumped >= 3) {
+        comboHits++;
+        if (comboHits >= comboMultiplier) {
+          comboMultiplier *= 2;
+          comboHits = 0;
         }
+        score += jumped * comboMultiplier;
       } else {
         score += jumped;
         comboMultiplier = 1;


### PR DESCRIPTION
## Summary
- revert combo tracking to earlier behavior based on skipped platforms
- retain jump height boost tied to high combo multipliers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689929381dac832090d9864318ec0254