### PR TITLE
Trigger combos only after skipping three tiles

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -133,7 +133,8 @@ function update() {
       player.vy = 0;
       player.onGround = true;
       const jumped = plat.id - player.lastPlatformId;
-      if (jumped >= 3) {
+      const skipped = jumped - 1; // number of platforms skipped in this jump
+      if (skipped >= 3) {
         comboHits++;
         if (comboHits >= comboMultiplier) {
           comboMultiplier *= 2;


### PR DESCRIPTION
## Summary
- adjust combo logic in `icy-tower/game.js` so combos start only when skipping at least three platforms in one jump
- compute and use a `skipped` count to track platforms bypassed during a jump

## Testing
- `node --check icy-tower/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68992a4b1e648320953fcec09a268eb0