### PR TITLE
Trigger long jump only after combo upgrade from x4

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -44,6 +44,7 @@ let gameOverDisplayed = false;
 let gameAreaWidth, gameAreaX;
 let platformSpacing, nextPlatformId, comboMultiplier, comboHits;
 let stars;
+let longJumpReady;
 
 function initGame(diff) {
   platformWidth = diff.platformWidth;
@@ -82,6 +83,7 @@ function initGame(diff) {
   nextPlatformId = num;
   comboMultiplier = 1;
   comboHits = 0;
+  longJumpReady = false;
   stars = [];
   keys = {};
   gameOver = false;
@@ -104,7 +106,11 @@ function update() {
   else player.vx = 0;
 
   if (keys['Space'] && player.onGround) {
-    const heightBoost = comboMultiplier >= 4 ? comboMultiplier / 2 : 1;
+    let heightBoost = 1;
+    if (longJumpReady && comboMultiplier >= 4) {
+      heightBoost = comboMultiplier / 2;
+      longJumpReady = false;
+    }
     player.vy = -20 * heightBoost;
     player.onGround = false;
     if (!gameStarted) gameStarted = true;
@@ -139,6 +145,7 @@ function update() {
           // first long jump starts the combo at x2
           comboMultiplier = 2;
           comboHits = 0;
+          longJumpReady = false;
         } else {
           // count consecutive long jumps after combo start
           comboHits++;
@@ -151,11 +158,15 @@ function update() {
         if (comboHits >= comboMultiplier) {
           comboMultiplier += 2;
           comboHits = 0;
+          if (comboMultiplier >= 4) {
+            longJumpReady = true;
+          }
         }
       } else {
         score += jumped;
         comboMultiplier = 1;
         comboHits = 0;
+        longJumpReady = false;
       }
       player.lastPlatformId = plat.id;
     }


### PR DESCRIPTION
## Summary
- Track when a combo multiplier upgrade occurs starting at x4 with a `longJumpReady` flag
- Consume the flag on the next jump to allow a one-time boosted leap and clear it when combos reset

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68992e1fe280832093724109bb9fdbeb