### PR TITLE
feat: improve game UI with instructions and combo display

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -6,9 +6,18 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <div id="instructions">
+    <p>Strzałki - ruch<br />Spacja - skok</p>
+  </div>
+  <div id="scoreboard">
+    <h2>Tabela wyników:</h2>
+    <pre id="scoreTable"></pre>
+  </div>
+
   <div id="menu">
     <h1>Icy Tower Clone</h1>
     <p>Umieść pliki <code>Background.jpg</code>, <code>step.jpg</code> i <code>character.jpg</code> w folderze <code>assets</code>, aby użyć własnych grafik.</p>
+    <p>Naciśnij Spację aby rozpocząć.</p>
     <div>
       <label>Poziom trudności:
         <select id="difficulty">
@@ -20,11 +29,15 @@
     </div>
     <button id="startBtn">Start</button>
   </div>
-  <canvas id="game" style="display:none;"></canvas>
+
+  <div id="gameContainer" style="display:none;">
+    <canvas id="game"></canvas>
+    <div id="currentScore">0</div>
+    <div id="comboDisplay"></div>
+  </div>
+
   <div id="gameOver" style="display:none;">
     <p id="finalScore"></p>
-    <h2>Tabela wyników:</h2>
-    <pre id="scoreTable"></pre>
     <input id="nickname" placeholder="Twój nick" />
     <button id="saveScoreBtn">Zapisz wynik</button>
     <button id="newGameBtn">Nowa Gra</button>

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -1,19 +1,41 @@
 body {
   font-family: Arial, sans-serif;
-  background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
-  text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
+  background: #222;
+  color: #fff;
   margin: 0;
 }
 
+#instructions,
+#scoreboard {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  width: 200px;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 100;
+}
+
+#instructions {
+  left: 0;
+}
+
+#scoreboard {
+  right: 0;
+}
+
 #menu {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: rgba(255, 255, 255, 0.9);
+  color: #000;
   padding: 40px;
   border-radius: 10px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  z-index: 50;
+  text-align: center;
 }
 
 #startBtn {
@@ -31,12 +53,50 @@ body {
   background: #45a049;
 }
 
+#gameContainer {
+  position: relative;
+  width: 600px;
+  height: 100vh;
+  margin: 0 auto;
+}
+
 #game {
   background: #fff;
-  border: none;
+  border: 4px solid #000;
   display: block;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
+}
+
+#currentScore {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 24px;
+}
+
+#comboDisplay {
+  position: absolute;
+  top: 50px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 32px;
+  color: yellow;
+  -webkit-text-stroke: 1px #000;
+  border: 2px solid yellow;
+  padding: 5px 10px;
+  display: none;
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    transform: translateX(-50%) scale(1);
+  }
+  50% {
+    transform: translateX(-50%) scale(1.2);
+  }
 }
 
 #gameOver {


### PR DESCRIPTION
## Summary
- keep instructions left and high-score table fixed right while playing
- darken background around play area and center score at top
- show pulsing yellow combo indicator and allow starting from menu with space

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899be73f5548320a000b5b887e39fb1