### PR TITLE
Add boost indicator and golden ring bonus

### DIFF
--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -82,9 +82,9 @@ body {
   left: 50%;
   transform: translateX(-50%);
   font-size: 32px;
-  color: yellow;
+  color: red;
   -webkit-text-stroke: 1px #000;
-  border: 2px solid yellow;
+  border: 2px solid red;
   padding: 5px 10px;
   display: none;
   animation: pulse 1s infinite;


### PR DESCRIPTION
## Summary
- Show red **BOOST!** message when performing long jumps instead of combo text
- Spawn golden rings on every 20th platform that grant 1000 points and briefly turn the score display gold
- Style boost message in red

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c13aba7c83208ecd985811c8e973