### PR TITLE
Display combo multiplier and show boost only on long jumps

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -262,6 +262,11 @@ function update() {
     comboDisplay.style.color = 'red';
     comboDisplay.style.borderColor = 'red';
     boostTimer--;
+  } else if (comboMultiplier > 1) {
+    comboDisplay.style.display = 'block';
+    comboDisplay.textContent = `KOMBO x${comboMultiplier}`;
+    comboDisplay.style.color = 'yellow';
+    comboDisplay.style.borderColor = 'yellow';
   } else {
     comboDisplay.style.display = 'none';
   }


### PR DESCRIPTION
## Summary
- Show "BOOST!" only when a long jump occurs
- Display ongoing combo status with a "KOMBO xN" indicator

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c34e31008320ae83c3984faab5bf