### PR TITLE
Add wall bounce with boost bar and refine boost display

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -14,26 +14,33 @@
     <pre id="scoreTable"></pre>
   </div>
 
-  <div id="menu">
-    <h1>Icy Tower Clone</h1>
-    <p>Umieść pliki <code>Background.jpg</code>, <code>step.jpg</code> i <code>character.jpg</code> w folderze <code>assets</code>, aby użyć własnych grafik.</p>
-    <p>Naciśnij Spację aby rozpocząć.</p>
-    <div>
-      <label>Poziom trudności:
-        <select id="difficulty">
-          <option value="easy">Łatwa</option>
-          <option value="medium">Średnia</option>
-          <option value="hard">Trudna</option>
-        </select>
-      </label>
+    <div id="menu">
+      <h1>Icy Tower Clone</h1>
+      <p>Umieść pliki <code>Background.jpg</code>, <code>step.jpg</code> i <code>character.jpg</code> w folderze <code>assets</code>, aby użyć własnych grafik.</p>
+      <p>Naciśnij Spację aby rozpocząć.</p>
+      <div>
+        <label>Poziom trudności:
+          <select id="difficulty">
+            <option value="easy">Łatwa</option>
+            <option value="medium">Średnia</option>
+            <option value="hard">Trudna</option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          <input type="checkbox" id="wallBounceToggle" checked />
+          Odbicia od ścian
+        </label>
+      </div>
+      <button id="startBtn">Start</button>
     </div>
-    <button id="startBtn">Start</button>
-  </div>
 
   <div id="gameContainer" style="display:none;">
     <canvas id="game"></canvas>
     <div id="currentScore">0</div>
     <div id="comboDisplay"></div>
+    <div id="wallBounceBar"><div id="wallBounceFill"></div></div>
   </div>
 
   <div id="gameOver" style="display:none;">

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -90,6 +90,24 @@ body {
   animation: pulse 1s infinite;
 }
 
+#wallBounceBar {
+  position: absolute;
+  top: 0;
+  right: -30px;
+  width: 20px;
+  height: 100%;
+  border: 2px solid #000;
+  background: #444;
+  display: none;
+}
+
+#wallBounceFill {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 0;
+}
+
 @keyframes pulse {
   0%, 100% {
     transform: translateX(-50%) scale(1);


### PR DESCRIPTION
## Summary
- Make "Boost!" only appear while performing a combo-powered long jump
- Introduce optional wall bounce mechanic with 10% speed/height boost and a five-level rainbow charge bar
- Expose wall bounce as a toggleable menu option enabled by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c60a5fb88320a14eee48317f65e0