### PR TITLE
Balance jump speed and wall bounce boost

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -70,8 +70,8 @@ document.addEventListener('keydown', e => {
   }
 });
 
-const gravity = 0.5;
-const jumpSpeed = 20;
+const gravity = 8;
+const jumpSpeed = 80;
 let platformWidth = 90;
 let speed = 2;
 
@@ -90,6 +90,7 @@ let stars, rings;
 let longJumpReady;
 let boostActive;
 let wallBounceEnabled, wallBounceCount, lastWallSide;
+let bounceSpeedBoost;
 
 function initGame(diff) {
   platformWidth = diff.platformWidth;
@@ -147,6 +148,7 @@ function initGame(diff) {
   boostActive = false;
   wallBounceCount = 0;
   lastWallSide = null;
+  bounceSpeedBoost = 1;
   wallBounceBar.style.display = wallBounceEnabled ? 'block' : 'none';
   updateBounceBar();
   scoreDisplay.style.color = '#fff';
@@ -167,9 +169,9 @@ function update() {
   }
 
   const inputX = (keys['ArrowLeft'] ? -1 : 0) + (keys['ArrowRight'] ? 1 : 0);
-  const accel = player.onGround ? groundAcceleration : airAcceleration;
+  const accel = (player.onGround ? groundAcceleration : airAcceleration) * bounceSpeedBoost;
   player.vx += inputX * accel;
-  const maxSpeed = player.onGround ? maxGroundSpeed : maxAirSpeed;
+  const maxSpeed = (player.onGround ? maxGroundSpeed : maxAirSpeed) * bounceSpeedBoost;
   if (player.vx > maxSpeed) player.vx = maxSpeed;
   if (player.vx < -maxSpeed) player.vx = -maxSpeed;
   if (player.onGround && inputX === 0) {
@@ -251,6 +253,7 @@ function update() {
 
   if (player.onGround) {
     boostActive = false;
+    bounceSpeedBoost = 1;
     if (wallBounceEnabled && wallBounceCount) {
       wallBounceCount = 0;
       updateBounceBar();
@@ -420,7 +423,8 @@ function handleWallBounce(isLeft) {
   player.vy = -jumpSpeed + gravity;
   player.y += player.vy - prevVy;
   const timeToGround = (-player.vy * 2) / gravity;
-  player.vx = dir * 0.75 * gameAreaWidth / timeToGround;
+  player.vx = dir * 0.75 * gameAreaWidth / timeToGround * 2;
+  bounceSpeedBoost = 2;
   player.wallBounceTimer = 5;
   if (wallBounceCount < maxWallBounceLevel) {
     wallBounceCount++;

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -7,13 +7,15 @@
 </head>
 <body>
   <div id="instructions">
-    <p>Strzałki - ruch<br />Spacja - skok</p>
-    <p>Złote obręcze dają 1000 punktów.<br />
-    Kombo zaczyna się po długim skoku z pominięciem co najmniej 3 platform i zwiększa mnożnik wyniku.<br />
-    Mnożnik rośnie o 2 po wymaganej liczbie długich skoków.<br />
-    Boost to wyższy skok dostępny od mnożnika 4.<br />
-    Odbicia od ścian (opcjonalne w menu) działają tylko podczas kombosa, mocno odbijają w przeciwną stronę i nie można odbić się dwa razy z rzędu od tej samej ściany.</p>
-  </div>
+  <ul>
+    <li>Strzałki – ruch</li>
+    <li>Spacja – skok</li>
+    <li>Złote obręcze: +1000 pkt</li>
+    <li>Kombos: pomiń ≥3 platformy, mnożnik rośnie co kilka długich skoków</li>
+    <li>Boost: wyższy skok przy mnożniku ≥4</li>
+    <li>Odbicia od ścian: tylko w kombosie, nie dwa razy z rzędu</li>
+  </ul>
+</div>
   <div id="scoreboard">
     <h2>Tabela wyników:</h2>
     <pre id="scoreTable"></pre>


### PR DESCRIPTION
## Summary
- Keep jump height steady by increasing gravity to match higher jump speed
- Double movement speed after wall bounces without stacking boosts

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6899d2e72f3883208b2c132ccbdbf14c