### PR TITLE
Revert to simpler physics model

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -13,7 +13,6 @@
     <li>Złote obręcze: +1000 pkt</li>
     <li>Kombos: pomiń ≥3 platformy, mnożnik rośnie co kilka długich skoków</li>
     <li>Boost: wyższy skok przy mnożniku ≥4</li>
-    <li>Odbicia od ścian: tylko w kombosie, nie dwa razy z rzędu</li>
   </ul>
 </div>
   <div id="scoreboard">
@@ -34,12 +33,6 @@
           </select>
         </label>
       </div>
-      <div>
-        <label>
-          <input type="checkbox" id="wallBounceToggle" checked />
-          Odbicia od ścian
-        </label>
-      </div>
       <button id="startBtn">Start</button>
     </div>
 
@@ -47,7 +40,6 @@
     <canvas id="game"></canvas>
     <div id="currentScore">0</div>
     <div id="comboDisplay"></div>
-    <div id="wallBounceBar"><div id="wallBounceFill"></div></div>
   </div>
 
   <div id="gameOver" style="display:none;">

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -90,24 +90,6 @@ body {
   animation: pulse 1s infinite;
 }
 
-#wallBounceBar {
-  position: absolute;
-  top: 0;
-  right: -30px;
-  width: 20px;
-  height: 100%;
-  border: 2px solid #000;
-  background: #444;
-  display: none;
-}
-
-#wallBounceFill {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 0;
-}
-
 @keyframes pulse {
   0%, 100% {
     transform: translateX(-50%) scale(1);


### PR DESCRIPTION
## Summary
- Revert `game.js` to earlier, simpler physics with basic gravity and jump mechanics.
- Remove wall bounce instructions and UI elements from HTML and CSS.

## Testing
- `node --check icy-tower/game.js`


------
https://chatgpt.com/codex/tasks/task_e_6899d7b7248c8320b188980e3714f294