### PR TITLE
feat: add wall bounce and speed controls

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -20,7 +20,19 @@
     <pre id="scoreTable"></pre>
   </div>
 
-    <div id="menu">
+  <div id="menu"><!-- WALL-BOUNCE options panel -->
+    <label>
+      <input type="checkbox" id="toggleWallBounce" />
+      Odbijanie od ścian
+    </label>
+    <div id="speedControl">
+      <button id="speedMinus">-</button>
+      <span id="speedValue">1x</span>
+      <button id="speedPlus">+</button>
+    </div>
+  </div>
+
+    <div id="mainMenu"><!-- WALL-BOUNCE renamed from menu -->
       <h1>Icy Tower Clone</h1>
       <p>Umieść pliki <code>Background.jpg</code>, <code>step.jpg</code> i <code>character.jpg</code> w folderze <code>assets</code>, aby użyć własnych grafik.</p>
       <p>Naciśnij Spację aby rozpocząć.</p>

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -24,7 +24,7 @@ body {
   right: 0;
 }
 
-#menu {
+#mainMenu { /* WALL-BOUNCE renamed from #menu */
   position: absolute;
   top: 50%;
   left: 50%;
@@ -147,4 +147,39 @@ body {
 
 #newGameBtn:hover {
   background: #1976d2;
+}
+
+#menu { /* WALL-BOUNCE */
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 8px;
+  font-size: 12px;
+  z-index: 150;
+}
+
+#menu label { /* WALL-BOUNCE */
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+#speedControl { /* WALL-BOUNCE */
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+}
+
+#speedControl button { /* WALL-BOUNCE */
+  width: 24px;
+  height: 24px;
+}
+
+#speedControl span { /* WALL-BOUNCE */
+  margin: 0 4px;
+  width: 40px;
+  text-align: center;
+  display: inline-block;
 }


### PR DESCRIPTION
## Summary
- add configuration block with wall bounce tuning and UI settings
- implement wall jump charging, optional wall slide and vertical charge bar
- introduce overlay menu with wall bounce toggle and speed +/- controls

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_6899dafcbd6c832082432e70e123d9f7