### PR TITLE
Add automatic jumping and consolidate menu options

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -9,7 +9,7 @@
   <div id="instructions">
   <ul>
     <li>Strzałki – ruch</li>
-    <li>Spacja – skok</li>
+    <li>Skok odbywa się automatycznie</li>
     <li>Złote obręcze: +1000 pkt</li>
     <li>Kombos: pomiń ≥3 platformy, mnożnik rośnie co kilka długich skoków</li>
     <li>Boost: wyższy skok przy mnożniku ≥4</li>
@@ -18,18 +18,6 @@
   <div id="scoreboard">
     <h2>Tabela wyników:</h2>
     <pre id="scoreTable"></pre>
-  </div>
-
-  <div id="menu"><!-- WALL-BOUNCE options panel -->
-    <label>
-      <input type="checkbox" id="toggleWallBounce" />
-      Odbijanie od ścian
-    </label>
-    <div id="speedControl">
-      <button id="speedMinus">-</button>
-      <span id="speedValue">1x</span>
-      <button id="speedPlus">+</button>
-    </div>
   </div>
 
     <div id="mainMenu"><!-- WALL-BOUNCE renamed from menu -->
@@ -44,6 +32,15 @@
             <option value="hard">Trudna</option>
           </select>
         </label>
+      </div>
+      <label>
+        <input type="checkbox" id="toggleWallBounce" />
+        Odbijanie od ścian
+      </label>
+      <div id="speedControl">
+        <button id="speedMinus">-</button>
+        <span id="speedValue">1x</span>
+        <button id="speedPlus">+</button>
       </div>
       <button id="startBtn">Start</button>
     </div>

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -149,23 +149,6 @@ body {
   background: #1976d2;
 }
 
-#menu { /* WALL-BOUNCE */
-  position: fixed;
-  top: 10px;
-  right: 10px;
-  background: rgba(0, 0, 0, 0.6);
-  color: #fff;
-  padding: 8px;
-  font-size: 12px;
-  z-index: 150;
-}
-
-#menu label { /* WALL-BOUNCE */
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
 #speedControl { /* WALL-BOUNCE */
   margin-top: 4px;
   display: flex;


### PR DESCRIPTION
## Summary
- make the player jump automatically and bounce off walls instead of sticking
- move wall bounce toggle and speed controls into the main menu and remove standalone options menu
- update instructions to mention automatic jumping

## Testing
- `node --check icy-tower/game.js`


------
https://chatgpt.com/codex/tasks/task_e_6899e529f0d88320a382cad3dbeff0bf