### PR TITLE
Refine wall bounce and redesign menu

### DIFF
--- a/icy-tower/assets/.gitignore
+++ b/icy-tower/assets/.gitignore
@@ -1,2 +1,3 @@
 # Ignore user-supplied assets
 *.jpg
+*.png

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -20,30 +20,34 @@
     <pre id="scoreTable"></pre>
   </div>
 
-    <div id="mainMenu"><!-- WALL-BOUNCE renamed from menu -->
-      <h1>Icy Tower Clone</h1>
-      <p>Umieść pliki <code>Background.jpg</code>, <code>step.jpg</code> i <code>character.jpg</code> w folderze <code>assets</code>, aby użyć własnych grafik.</p>
-      <p>Naciśnij Spację aby rozpocząć.</p>
-      <div>
-        <label>Poziom trudności:
-          <select id="difficulty">
-            <option value="easy">Łatwa</option>
-            <option value="medium">Średnia</option>
-            <option value="hard">Trudna</option>
-          </select>
-        </label>
-      </div>
-      <label>
-        <input type="checkbox" id="toggleWallBounce" />
-        Odbijanie od ścian
+  <div id="mainMenu" class="menu"><!-- WALL-BOUNCE renamed from menu -->
+    <img id="logo" src="assets/logo.png" alt="Logo" />
+    <button id="startBtn" class="menu-button">Nowa gra</button>
+    <button id="settingsBtn" class="menu-button">Ustawienia</button>
+  </div>
+
+  <div id="settingsMenu" class="menu" style="display:none;">
+    <h2>Ustawienia</h2>
+    <div>
+      <label>Poziom trudności:
+        <select id="difficulty">
+          <option value="easy">Łatwa</option>
+          <option value="medium">Średnia</option>
+          <option value="hard">Trudna</option>
+        </select>
       </label>
-      <div id="speedControl">
-        <button id="speedMinus">-</button>
-        <span id="speedValue">1x</span>
-        <button id="speedPlus">+</button>
-      </div>
-      <button id="startBtn">Start</button>
     </div>
+    <label>
+      <input type="checkbox" id="toggleWallBounce" />
+      Odbijanie od ścian
+    </label>
+    <div id="speedControl">
+      <button id="speedMinus">-</button>
+      <span id="speedValue">1x</span>
+      <button id="speedPlus">+</button>
+    </div>
+    <button id="backBtn" class="menu-button">Wróć</button>
+  </div>
 
   <div id="gameContainer" style="display:none;">
     <canvas id="game"></canvas>

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -24,33 +24,41 @@ body {
   right: 0;
 }
 
-#mainMenu { /* WALL-BOUNCE renamed from #menu */
+.menu {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(255, 255, 255, 0.9);
-  color: #000;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
   padding: 40px;
   border-radius: 10px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
   z-index: 50;
   text-align: center;
 }
 
-#startBtn {
-  background: #4caf50;
-  color: #fff;
-  border: none;
+.menu-button {
+  display: block;
+  width: 200px;
+  margin: 10px auto;
   padding: 10px 20px;
   font-size: 1rem;
-  border-radius: 5px;
+  background: rgba(20, 20, 20, 0.8);
+  color: #fff;
+  border: 2px solid #fff;
+  border-radius: 8px;
   cursor: pointer;
-  margin-top: 15px;
 }
 
-#startBtn:hover {
-  background: #45a049;
+.menu-button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+#logo {
+  display: block;
+  margin: 0 auto 20px;
+  max-width: 200px;
 }
 
 #gameContainer {


### PR DESCRIPTION
## Summary
- Prevent double bounces off the same wall and keep horizontal speed normal while boosting jump height by 1.5×
- Remove debug logging and unused configuration while preserving the game-style menu with logo slot and settings panel
- Stop tracking PNG assets and ignore future PNG additions

## Testing
- `node --check icy-tower/game.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6899ee46121c8320a9323fc3c4d7a37c