### PR TITLE
Increase wall bounce range and remove character outline

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -161,7 +161,8 @@ function initGame(diff) {
       this.wallBounceCount++;
     }
     this.lastBounceDir = this.wallContactDir;
-    this.vx = -this.wallContactDir * 4 * game.settings.speedMultiplier;
+    // give the player extra horizontal distance after bouncing off a wall
+    this.vx = -this.wallContactDir * 8 * game.settings.speedMultiplier;
     this.vy = -20 * 1.5 * game.settings.speedMultiplier;
     this.flipping = true;
     this.rotation = 0;
@@ -476,9 +477,7 @@ function draw() {
     ctx.fillStyle = '#0a0';
     ctx.fillRect(-player.width / 2, -player.height / 2, player.width, player.height);
   }
-  ctx.strokeStyle = '#000';
-  ctx.lineWidth = borderWidth;
-  ctx.strokeRect(-player.width / 2, -player.height / 2, player.width, player.height);
+  // character sprite has no black outline
   ctx.restore();
 
   drawBounceBar(); // WALL-BOUNCE


### PR DESCRIPTION
## Summary
- Allow wall bounces to push the player twice as far horizontally
- Remove black outline around character sprite

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f563c7e88320a44488091330db96