### PR TITLE
Add retro Tone.js melody with music toggle

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -46,6 +46,10 @@
       <span id="speedValue">1x</span>
       <button id="speedPlus">+</button>
     </div>
+    <label>
+      <input type="checkbox" id="toggleMusic" checked />
+      Muzyka
+    </label>
     <button id="backBtn" class="menu-button">Wróć</button>
   </div>
 
@@ -61,6 +65,7 @@
     <button id="saveScoreBtn">Zapisz wynik</button>
     <button id="newGameBtn">Nowa Gra</button>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.39/Tone.min.js"></script>
   <script src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add settings checkbox to enable or disable background music
- Integrate Tone.js with a looping C-major melody at 120 BPM
- Start or stop the melody based on user preferences

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3134f6e48320811dca6634340b72