### PR TITLE
Extend game music with energetic bass loop

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -62,24 +62,44 @@ toggleMusic.addEventListener('change', () => {
   }
 });
 
-// simple retro melody using Tone.js
+// upbeat chiptune loop using Tone.js
 const synth = new Tone.MonoSynth({
-  oscillator: { type: 'square' },
-  envelope: { attack: 0.05, decay: 0.2, sustain: 0.2, release: 0.8 }
+  oscillator: { type: 'sawtooth' },
+  envelope: { attack: 0.02, decay: 0.1, sustain: 0.2, release: 0.4 }
 }).toDestination();
-Tone.Transport.bpm.value = 120;
-const melody = ['C4', 'E4', 'G4', 'C5', 'E5', 'G5', 'E5', 'C5'];
+const bassSynth = new Tone.MonoSynth({
+  oscillator: { type: 'square' },
+  filter: { type: 'lowpass', frequency: 200 },
+  envelope: { attack: 0.01, decay: 0.2, sustain: 0.3, release: 0.8 }
+}).toDestination();
+const kick = new Tone.MembraneSynth().toDestination();
+
+Tone.Transport.bpm.value = 160;
+
+const melody = [
+  'C4', 'E4', 'G4', 'B4', 'C5', 'B4', 'G4', 'E4',
+  'D4', 'F4', 'A4', 'C5', 'D5', 'A4', 'F4', 'D4'
+];
+const bassline = ['C2', 'C2', 'G1', 'C2', 'B1', 'G1', 'C2', 'G1'];
+
 const sequence = new Tone.Sequence((time, note) => {
-  synth.triggerAttackRelease(note, '8n', time);
-}, melody, '8n');
+  synth.triggerAttackRelease(note, '16n', time);
+}, melody, '16n');
+const bassSequence = new Tone.Sequence((time, note) => {
+  bassSynth.triggerAttackRelease(note, '8n', time);
+  kick.triggerAttackRelease('C2', '8n', time);
+}, bassline, '8n');
+
 sequence.loop = true;
+bassSequence.loop = true;
 Tone.Transport.loop = true;
-Tone.Transport.loopEnd = '1m';
+Tone.Transport.loopEnd = '90s'; // roughly 1.5 minutes
 
 function startMusic() {
   Tone.start();
   if (sequence.state !== 'started') {
     sequence.start(0);
+    bassSequence.start(0);
   }
   Tone.Transport.start();
 }


### PR DESCRIPTION
## Summary
- Replace simple 8-note melody with upbeat chiptune pattern
- Add bass and kick sequences for a bouncy feel
- Loop transport for roughly 1.5-minute track

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3581302c8320aaaf1103668855dd