### PR TITLE
Add toggle for continuous mode with periodic stop platforms

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -50,6 +50,10 @@
       <input type="checkbox" id="toggleMusic" checked />
       Muzyka
     </label>
+    <label>
+      <input type="checkbox" id="toggleContinuous" checked />
+      Gra ciągła
+    </label>
     <button id="backBtn" class="menu-button">Wróć</button>
   </div>
 


### PR DESCRIPTION
## Summary
- add *Gra ciągła* checkbox in settings
- allow disabling continuous play and pause on every 100th platform

## Testing
- `node --check icy-tower/game.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e5c67005c832093c9201352ce0788