### PR TITLE
Add Arcade and Boost modes

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -9,18 +9,18 @@ const config = {
 
 const savedSetting = localStorage.getItem('wallBounceEnabled'); // WALL-BOUNCE
 const savedMusic = localStorage.getItem('musicEnabled');
-const savedContinuous = localStorage.getItem('continuousPlay');
 const game = { // WALL-BOUNCE
   settings: {
     wallBounceEnabled: savedSetting !== null ? JSON.parse(savedSetting) : config.wallBounceEnabledDefault,
     speedMultiplier: 1,
     musicEnabled: savedMusic !== null ? JSON.parse(savedMusic) : true,
-    continuousPlay: savedContinuous !== null ? JSON.parse(savedContinuous) : true
+    continuousPlay: true
   }
 };
 
 const menu = document.getElementById('mainMenu'); // WALL-BOUNCE start menu renamed
-const startBtn = document.getElementById('startBtn');
+const arcadeBtn = document.getElementById('arcadeBtn');
+const boostBtn = document.getElementById('boostBtn');
 const settingsBtn = document.getElementById('settingsBtn');
 const settingsMenu = document.getElementById('settingsMenu');
 const backBtn = document.getElementById('backBtn');
@@ -38,10 +38,8 @@ const speedMinus = document.getElementById('speedMinus');
 const speedPlus = document.getElementById('speedPlus');
 const speedValue = document.getElementById('speedValue');
 const toggleMusic = document.getElementById('toggleMusic');
-const toggleContinuous = document.getElementById('toggleContinuous');
 toggleWallBounce.checked = game.settings.wallBounceEnabled;
 toggleMusic.checked = game.settings.musicEnabled;
-toggleContinuous.checked = game.settings.continuousPlay;
 function updateSpeedLabel() { speedValue.textContent = game.settings.speedMultiplier.toFixed(1) + 'x'; }
 updateSpeedLabel();
 toggleWallBounce.addEventListener('change', () => {
@@ -64,10 +62,6 @@ toggleMusic.addEventListener('change', () => {
   } else {
     stopMusic();
   }
-});
-toggleContinuous.addEventListener('change', () => {
-  game.settings.continuousPlay = toggleContinuous.checked;
-  localStorage.setItem('continuousPlay', game.settings.continuousPlay);
 });
 
 // upbeat chiptune loop using Tone.js
@@ -170,13 +164,21 @@ function startGame() {
   requestAnimationFrame(loop);
 }
 
-startBtn.addEventListener('click', startGame);
+arcadeBtn.addEventListener('click', () => {
+  game.settings.continuousPlay = true;
+  startGame();
+});
+
+boostBtn.addEventListener('click', () => {
+  game.settings.continuousPlay = false;
+  startGame();
+});
 
 document.addEventListener('keydown', e => {
   if (gameOverDiv.style.display !== 'none' && e.code === 'Space') {
     newGameBtn.click();
   } else if (menu.style.display !== 'none' && e.code === 'Space') {
-    startGame();
+    arcadeBtn.click();
   } else if (paused && e.code === 'Space') {
     paused = false;
   }

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -22,7 +22,8 @@
 
   <div id="mainMenu" class="menu"><!-- WALL-BOUNCE renamed from menu -->
     <img id="logo" src="assets/logo.png" alt="Logo" />
-    <button id="startBtn" class="menu-button">Nowa gra</button>
+    <button id="arcadeBtn" class="menu-button">Arcade Mode</button>
+    <button id="boostBtn" class="menu-button">Boost Mode</button>
     <button id="settingsBtn" class="menu-button">Ustawienia</button>
   </div>
 
@@ -49,10 +50,6 @@
     <label>
       <input type="checkbox" id="toggleMusic" checked />
       Muzyka
-    </label>
-    <label>
-      <input type="checkbox" id="toggleContinuous" checked />
-      Gra ciągła
     </label>
     <button id="backBtn" class="menu-button">Wróć</button>
   </div>


### PR DESCRIPTION
## Summary
- Replace settings toggle for continuous play with new main menu options
- Implement Arcade Mode for continuous play and Boost Mode for non-continuous play

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e608137488320ac4db7651c633e3e