### PR TITLE
Implement skill wheel and color-based bonuses

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -13,6 +13,10 @@
     <li>Złote obręcze: +1000 pkt</li>
     <li>Kombos: pomiń ≥4 platformy, mnożnik rośnie co kilka długich skoków</li>
     <li>Boost: wyższy skok przy mnożniku ≥4</li>
+    <li>Czerwony skill: skaczesz o 1/4 wyżej</li>
+    <li>Żółty skill: zdobywasz o 1/4 punktów więcej</li>
+    <li>Zielony skill: odbicia od ścian są 2× wyższe</li>
+    <li>Niebieski skill: stopnie są o 1/4 szersze</li>
   </ul>
 </div>
   <div id="scoreboard">
@@ -63,9 +67,15 @@
       <div class="boost-frame"></div>
       <div class="boost-frame"></div>
     </div>
+    <div id="skills">
+      <div class="skill-slot"></div>
+      <div class="skill-slot"></div>
+      <div class="skill-slot"></div>
+    </div>
   </div>
 
   <div id="wheelOverlay" style="display:none;">
+    <div id="wheelPointer"></div>
     <canvas id="spinWheel" width="200" height="200"></canvas>
     <button id="spinBtn">Spin!</button>
   </div>

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -174,6 +174,31 @@ body {
   background: rgba(255, 255, 255, 0.2);
 }
 
+#skills {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 5px;
+}
+
+.skill-slot {
+  width: 40px;
+  height: 40px;
+  background: #fff;
+  border: 2px solid #000;
+}
+
+#wheelPointer {
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 20px solid #fff;
+  margin-bottom: 10px;
+}
+
 #nickname {
   margin-top: 15px;
   padding: 8px;


### PR DESCRIPTION
## Summary
- Add wheel with four alternating colors and pointer that always lands on a full segment
- Track up to three skills and display them in bottom slots
- Apply skill effects: higher jumps, bonus scoring, stronger wall bounces, and wider platforms

## Testing
- `node --check icy-tower/game.js`


------
https://chatgpt.com/codex/tasks/task_e_689e684ec2fc832094d5ebafb721102f