### PR TITLE
Move and reset skill slots

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -176,9 +176,19 @@ wheelCanvas.addEventListener('transitionend', () => {
 });
 
 function addSkill(color) {
-  boosterSlots[nextSkillIndex].style.borderColor = color;
+  boosterSlots[nextSkillIndex].style.backgroundColor = color;
   skills[nextSkillIndex] = color;
   nextSkillIndex = (nextSkillIndex + 1) % boosterSlots.length;
+  updateSkillEffects();
+}
+
+function resetSkills() {
+  skills = Array(boosterSlots.length).fill('');
+  nextSkillIndex = 0;
+  for (let slot of boosterSlots) {
+    slot.style.backgroundColor = '';
+    slot.style.borderColor = '#fff';
+  }
   updateSkillEffects();
 }
 
@@ -241,6 +251,7 @@ function updateScoreboard() {
 updateScoreboard();
 
 function startGame() {
+  resetSkills();
   menu.style.display = 'none';
   gameContainer.style.display = 'block';
   wheelOverlay.style.display = 'none';
@@ -674,6 +685,7 @@ function showGameOverScreen() {
   finalScore.textContent = `Gratulacje! Twój wynik: ${score}`;
   updateScoreboard();
   gameOverDiv.style.display = 'flex';
+  resetSkills();
 }
 
 saveScoreBtn.addEventListener('click', () => {

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -125,8 +125,8 @@ body {
 /* Booster frames */
 .booster-frames {
   position: absolute;
-  bottom: 10px;
-  right: 10px;
+  bottom: -60px;
+  right: -60px;
   display: flex;
   flex-direction: column;
   gap: 5px;
@@ -136,6 +136,7 @@ body {
   width: 40px;
   height: 40px;
   border: 2px solid #fff;
+  background-color: transparent;
 }
 
 /* Wheel overlay */


### PR DESCRIPTION
## Summary
- Fill skill slots with their color while keeping white borders
- Reset all skill effects when a game ends
- Display skill slots outside the game board in the bottom-right

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e6f634c3c8320a29de3ba739fd4ee