### PR TITLE
Add persistent ring counter and Shop menu

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -37,6 +37,13 @@ const wheelOverlay = document.getElementById('wheelOverlay');
 const spinBtn = document.getElementById('spinBtn');
 const wheelCanvas = document.getElementById('spinWheel');
 const wheelCtx = wheelCanvas.getContext('2d');
+const shopBtn = document.getElementById('shopBtn');
+const shopMenu = document.getElementById('shopMenu');
+const shopBackBtn = document.getElementById('shopBackBtn');
+const ringDisplay = document.getElementById('ringDisplay');
+const shopRingDisplay = document.getElementById('shopRingDisplay');
+const savedRings = parseInt(localStorage.getItem('ringCount')) || 0;
+let ringCount = savedRings;
 let wheelSpun = false;
 let spinning = false;
 const boosterSlots = document.querySelectorAll('.booster-frame');
@@ -76,6 +83,13 @@ toggleMusic.addEventListener('change', () => {
     stopMusic();
   }
 });
+
+function updateRingDisplay() {
+  if (ringDisplay) ringDisplay.textContent = `Obręcze: ${ringCount}`;
+  if (shopRingDisplay) shopRingDisplay.textContent = `Obręcze: ${ringCount}`;
+}
+
+updateRingDisplay();
 
 // upbeat chiptune loop using Tone.js
 const synth = new Tone.MonoSynth({
@@ -218,6 +232,19 @@ settingsBtn.addEventListener('click', () => {
 backBtn.addEventListener('click', () => {
   settingsMenu.style.display = 'none';
   menu.style.display = 'block';
+  updateRingDisplay();
+});
+
+shopBtn.addEventListener('click', () => {
+  menu.style.display = 'none';
+  shopMenu.style.display = 'block';
+  updateRingDisplay();
+});
+
+shopBackBtn.addEventListener('click', () => {
+  shopMenu.style.display = 'none';
+  menu.style.display = 'block';
+  updateRingDisplay();
 });
 
 let backgroundImg = new Image();
@@ -586,6 +613,9 @@ function update(now) { // WALL-BOUNCE
       player.y + player.height > ring.y - ring.radius
     ) {
       rings.splice(i, 1);
+      ringCount++;
+      localStorage.setItem('ringCount', ringCount);
+      updateRingDisplay();
       score += Math.round(1000 * (1 + 0.25 * yellowCount));
       scoreDisplay.style.color = 'gold';
       setTimeout(() => (scoreDisplay.style.color = '#fff'), 1000);
@@ -779,6 +809,7 @@ newGameBtn.addEventListener('click', () => {
    boosterFrames.style.display = 'none';
   document.getElementById('nickname').value = '';
   saveScoreBtn.disabled = false;
+  updateRingDisplay();
 });
 
 function loop(now) { // WALL-BOUNCE

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -26,9 +26,11 @@
 
   <div id="mainMenu" class="menu"><!-- WALL-BOUNCE renamed from menu -->
     <img id="logo" src="assets/logo.png" alt="Logo" />
+    <div id="ringDisplay" class="ring-display">Obręcze: 0</div>
     <button id="arcadeBtn" class="menu-button">Arcade Mode</button>
     <button id="boosterBtn" class="menu-button">Booster Mode</button>
     <button id="settingsBtn" class="menu-button">Ustawienia</button>
+    <button id="shopBtn" class="menu-button">Shop</button>
   </div>
 
   <div id="settingsMenu" class="menu" style="display:none;">
@@ -56,6 +58,13 @@
       Muzyka
     </label>
     <button id="backBtn" class="menu-button">Wróć</button>
+  </div>
+
+  <div id="shopMenu" class="menu" style="display:none; position:relative;">
+    <h2>Sklep</h2>
+    <p>W przyszłości pojawią się tutaj przedmioty do kupienia.</p>
+    <div id="shopRingDisplay" class="ring-display"></div>
+    <button id="shopBackBtn" class="menu-button shop-back">Menu</button>
   </div>
 
   <div id="gameContainer" style="display:none;">

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -55,6 +55,22 @@ body {
   background: rgba(255, 255, 255, 0.2);
 }
 
+#ringDisplay,
+#shopRingDisplay,
+.ring-display {
+  margin-bottom: 10px;
+}
+
+#shopMenu {
+  position: relative;
+}
+
+.shop-back {
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
+}
+
 #logo {
   display: block;
   margin: 0 auto 20px;


### PR DESCRIPTION
## Summary
- Count collected yellow rings, store them in localStorage, and show total rings in main menu and shop
- Introduce placeholder Shop menu with a button to return to main menu
- Style ring counter and shop layout

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check icy-tower/game.js && echo syntaxOK`


------
https://chatgpt.com/codex/tasks/task_e_68a71a0d368c83208fc4a0d2c52ede4a