### PR TITLE
Add purchasable extra skill slot

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -42,12 +42,15 @@ const shopMenu = document.getElementById('shopMenu');
 const shopBackBtn = document.getElementById('shopBackBtn');
 const ringDisplay = document.getElementById('ringDisplay');
 const shopRingDisplay = document.getElementById('shopRingDisplay');
+const buySlotBtn = document.getElementById('buySlotBtn');
 const savedRings = parseInt(localStorage.getItem('ringCount')) || 0;
 let ringCount = savedRings;
+let extraSlotPurchased = localStorage.getItem('extraSlotPurchased') === 'true';
+const SLOT_PRICE = 50;
 let wheelSpun = false;
 let spinning = false;
-const boosterSlots = document.querySelectorAll('.booster-frame');
-let skills = Array(boosterSlots.length).fill('');
+let boosterSlots;
+let skills = [];
 let nextSkillIndex = 0;
 let redCount = 0, yellowCount = 0, greenCount = 0, blueCount = 0;
 const wheelColors = ['red', 'yellow', 'green', 'blue', 'red', 'yellow', 'green', 'blue'];
@@ -87,6 +90,17 @@ toggleMusic.addEventListener('change', () => {
 function updateRingDisplay() {
   if (ringDisplay) ringDisplay.textContent = `Obręcze: ${ringCount}`;
   if (shopRingDisplay) shopRingDisplay.textContent = `Obręcze: ${ringCount}`;
+}
+
+function initBoosterSlots() {
+  const count = extraSlotPurchased ? 4 : 3;
+  boosterFrames.innerHTML = '';
+  for (let i = 0; i < count; i++) {
+    const slot = document.createElement('div');
+    slot.className = 'booster-frame';
+    boosterFrames.appendChild(slot);
+  }
+  boosterSlots = boosterFrames.querySelectorAll('.booster-frame');
 }
 
 updateRingDisplay();
@@ -224,6 +238,9 @@ function updateSkillEffects() {
   }
 }
 
+initBoosterSlots();
+resetSkills();
+
 settingsBtn.addEventListener('click', () => {
   menu.style.display = 'none';
   settingsMenu.style.display = 'block';
@@ -246,6 +263,28 @@ shopBackBtn.addEventListener('click', () => {
   menu.style.display = 'block';
   updateRingDisplay();
 });
+
+if (buySlotBtn && extraSlotPurchased) {
+  buySlotBtn.disabled = true;
+  buySlotBtn.textContent = 'Kupiono';
+}
+
+if (buySlotBtn) {
+  buySlotBtn.addEventListener('click', () => {
+    if (extraSlotPurchased) return;
+    if (ringCount >= SLOT_PRICE) {
+      ringCount -= SLOT_PRICE;
+      localStorage.setItem('ringCount', ringCount);
+      extraSlotPurchased = true;
+      localStorage.setItem('extraSlotPurchased', 'true');
+      buySlotBtn.disabled = true;
+      buySlotBtn.textContent = 'Kupiono';
+      updateRingDisplay();
+      initBoosterSlots();
+      resetSkills();
+    }
+  });
+}
 
 let backgroundImg = new Image();
 let prevBackgroundImg = null;

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -62,8 +62,13 @@
 
   <div id="shopMenu" class="menu" style="display:none; position:relative;">
     <h2>Sklep</h2>
-    <p>W przyszłości pojawią się tutaj przedmioty do kupienia.</p>
     <div id="shopRingDisplay" class="ring-display"></div>
+    <div id="extraSlotItem" class="shop-item">
+      <div class="slot-preview"><div class="slot-inner"></div></div>
+      <button id="buySlotBtn" class="menu-button buy-button">
+        <span class="ring-icon"></span>50
+      </button>
+    </div>
     <button id="shopBackBtn" class="menu-button shop-back">Menu</button>
   </div>
 

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -71,6 +71,46 @@ body {
   bottom: 20px;
 }
 
+.shop-item {
+  display: inline-block;
+  margin: 20px;
+  text-align: center;
+}
+
+.slot-preview {
+  width: 60px;
+  height: 60px;
+  border: 4px solid #000;
+  background: #777;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 10px;
+}
+
+.slot-inner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #000;
+  background: #fff;
+}
+
+.buy-button {
+  width: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.ring-icon {
+  width: 16px;
+  height: 16px;
+  border: 4px solid gold;
+  border-radius: 50%;
+  display: inline-block;
+}
+
 #logo {
   display: block;
   margin: 0 auto 20px;


### PR DESCRIPTION
## Summary
- Add shop item allowing players to buy a permanent fourth skill slot for 50 rings
- Style shop item with nested squares and ring price icon, include menu return button
- Persist purchase and dynamically expand booster slots after buying

## Testing
- `node --version`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a71d95043c8320ba54662b586d4e0f