### PR TITLE
Add shop item for extra skill slot

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -40,14 +40,29 @@ const wheelCtx = wheelCanvas.getContext('2d');
 const shopBtn = document.getElementById('shopBtn');
 const shopMenu = document.getElementById('shopMenu');
 const shopBackBtn = document.getElementById('shopBackBtn');
+const buySlotItem = document.getElementById('buySlotItem');
 const ringDisplay = document.getElementById('ringDisplay');
 const shopRingDisplay = document.getElementById('shopRingDisplay');
 const savedRings = parseInt(localStorage.getItem('ringCount')) || 0;
 let ringCount = savedRings;
 let wheelSpun = false;
 let spinning = false;
-const boosterSlots = document.querySelectorAll('.booster-frame');
+let boosterSlots = Array.from(document.querySelectorAll('.booster-frame'));
 let skills = Array(boosterSlots.length).fill('');
+let extraSkillSlots = parseInt(localStorage.getItem('extraSkillSlots')) || 0;
+
+function createBoosterSlot() {
+  const slot = document.createElement('div');
+  slot.classList.add('booster-frame');
+  boosterFrames.appendChild(slot);
+  boosterSlots.push(slot);
+  skills.push('');
+}
+
+for (let i = 0; i < extraSkillSlots; i++) {
+  createBoosterSlot();
+}
+
 let nextSkillIndex = 0;
 let redCount = 0, yellowCount = 0, greenCount = 0, blueCount = 0;
 const wheelColors = ['red', 'yellow', 'green', 'blue', 'red', 'yellow', 'green', 'blue'];
@@ -246,6 +261,19 @@ shopBackBtn.addEventListener('click', () => {
   menu.style.display = 'block';
   updateRingDisplay();
 });
+
+if (buySlotItem) {
+  buySlotItem.addEventListener('click', () => {
+    if (ringCount >= 50) {
+      ringCount -= 50;
+      localStorage.setItem('ringCount', ringCount);
+      updateRingDisplay();
+      createBoosterSlot();
+      extraSkillSlots++;
+      localStorage.setItem('extraSkillSlots', extraSkillSlots);
+    }
+  });
+}
 
 let backgroundImg = new Image();
 let prevBackgroundImg = null;

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -62,8 +62,11 @@
 
   <div id="shopMenu" class="menu" style="display:none; position:relative;">
     <h2>Sklep</h2>
-    <p>W przyszłości pojawią się tutaj przedmioty do kupienia.</p>
     <div id="shopRingDisplay" class="ring-display"></div>
+    <div id="buySlotItem" class="shop-item">
+      <span class="ring-icon">💍</span>
+      <span class="price">50</span>
+    </div>
     <button id="shopBackBtn" class="menu-button shop-back">Menu</button>
   </div>
 

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -65,6 +65,29 @@ body {
   position: relative;
 }
 
+.shop-item {
+  width: 60px;
+  height: 60px;
+  background: #fff;
+  border: 2px solid #aaa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 10px auto;
+  cursor: pointer;
+  color: #000;
+  position: relative;
+}
+
+.shop-item .ring-icon {
+  font-size: 24px;
+  margin-right: 4px;
+}
+
+.shop-item .price {
+  font-size: 14px;
+}
+
 .shop-back {
   position: absolute;
   right: 20px;


### PR DESCRIPTION
## Summary
- Allow buying extra skill slots for 50 rings
- Show purchasable slot item in shop and update ring display
- Persist additional slots via localStorage and provide shop return button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a720b4d0988320a4211bee39af3f9b