### PR TITLE
Align shop panel with settings menu and add purchase feedback

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -43,6 +43,7 @@ const shopBackBtn = document.getElementById('shopBackBtn');
 const buySlotItem = document.getElementById('buySlotItem');
 const ringDisplay = document.getElementById('ringDisplay');
 const shopRingDisplay = document.getElementById('shopRingDisplay');
+const shopMessage = document.getElementById('shopMessage');
 const savedRings = parseInt(localStorage.getItem('ringCount')) || 0;
 let ringCount = savedRings;
 let wheelSpun = false;
@@ -102,6 +103,15 @@ toggleMusic.addEventListener('change', () => {
 function updateRingDisplay() {
   if (ringDisplay) ringDisplay.textContent = `Obręcze: ${ringCount}`;
   if (shopRingDisplay) shopRingDisplay.textContent = `Obręcze: ${ringCount}`;
+}
+
+function showShopMessage(msg) {
+  if (!shopMessage) return;
+  shopMessage.textContent = msg;
+  shopMessage.style.display = 'block';
+  setTimeout(() => {
+    shopMessage.style.display = 'none';
+  }, 5000);
 }
 
 updateRingDisplay();
@@ -271,6 +281,9 @@ if (buySlotItem) {
       createBoosterSlot();
       extraSkillSlots++;
       localStorage.setItem('extraSkillSlots', extraSkillSlots);
+    } else {
+      showShopMessage('Brak środków!');
+      updateRingDisplay();
     }
   });
 }

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -60,14 +60,15 @@
     <button id="backBtn" class="menu-button">Wróć</button>
   </div>
 
-  <div id="shopMenu" class="menu" style="display:none; position:relative;">
+  <div id="shopMenu" class="menu" style="display:none;">
     <h2>Sklep</h2>
     <div id="shopRingDisplay" class="ring-display"></div>
     <div id="buySlotItem" class="shop-item">
-      <span class="ring-icon">💍</span>
+      <div class="ring-icon"></div>
       <span class="price">50</span>
     </div>
-    <button id="shopBackBtn" class="menu-button shop-back">Menu</button>
+    <div id="shopMessage" class="shop-message"></div>
+    <button id="shopBackBtn" class="menu-button">Wróć</button>
   </div>
 
   <div id="gameContainer" style="display:none;">

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -61,10 +61,6 @@ body {
   margin-bottom: 10px;
 }
 
-#shopMenu {
-  position: relative;
-}
-
 .shop-item {
   width: 60px;
   height: 60px;
@@ -76,22 +72,25 @@ body {
   margin: 10px auto;
   cursor: pointer;
   color: #000;
-  position: relative;
 }
 
 .shop-item .ring-icon {
-  font-size: 24px;
+  width: 30px;
+  height: 30px;
+  border: 5px solid gold;
+  border-radius: 50%;
   margin-right: 4px;
+  box-sizing: border-box;
 }
 
 .shop-item .price {
   font-size: 14px;
 }
 
-.shop-back {
-  position: absolute;
-  right: 20px;
-  bottom: 20px;
+.shop-message {
+  color: red;
+  margin-top: 10px;
+  display: none;
 }
 
 #logo {


### PR DESCRIPTION
## Summary
- Match shop panel dimensions and back button placement to the settings menu
- Style shop item with a gold ring icon resembling in-game rings and show ring count
- Display "Brak środków!" for 5 seconds when purchase funds are insufficient

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a724b0e46883208c17e3c8851513c6