### PR TITLE
Add game reset and purchase refund options

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -44,6 +44,8 @@ const buySlotItem = document.getElementById('buySlotItem');
 const ringDisplay = document.getElementById('ringDisplay');
 const shopRingDisplay = document.getElementById('shopRingDisplay');
 const shopMessage = document.getElementById('shopMessage');
+const refundBtn = document.getElementById('refundBtn');
+const resetGameBtn = document.getElementById('resetGameBtn');
 const savedRings = parseInt(localStorage.getItem('ringCount')) || 0;
 let ringCount = savedRings;
 let wheelSpun = false;
@@ -60,9 +62,19 @@ function createBoosterSlot() {
   skills.push('');
 }
 
+function removeExtraSlots() {
+  while (boosterSlots.length > 3) {
+    const slot = boosterSlots.pop();
+    boosterFrames.removeChild(slot);
+    skills.pop();
+  }
+}
+
 for (let i = 0; i < extraSkillSlots; i++) {
   createBoosterSlot();
 }
+
+updateShopItem();
 
 let nextSkillIndex = 0;
 let redCount = 0, yellowCount = 0, greenCount = 0, blueCount = 0;
@@ -112,6 +124,35 @@ function showShopMessage(msg) {
   setTimeout(() => {
     shopMessage.style.display = 'none';
   }, 5000);
+}
+
+function updateShopItem() {
+  if (!buySlotItem) return;
+  if (extraSkillSlots > 0) {
+    buySlotItem.classList.add('purchased');
+  } else {
+    buySlotItem.classList.remove('purchased');
+  }
+}
+
+function refundPurchases() {
+  ringCount += extraSkillSlots * 50;
+  extraSkillSlots = 0;
+  localStorage.setItem('ringCount', ringCount);
+  localStorage.setItem('extraSkillSlots', extraSkillSlots);
+  removeExtraSlots();
+  updateRingDisplay();
+  updateShopItem();
+}
+
+function resetGame() {
+  ringCount = 0;
+  extraSkillSlots = 0;
+  localStorage.setItem('ringCount', ringCount);
+  localStorage.setItem('extraSkillSlots', extraSkillSlots);
+  removeExtraSlots();
+  updateRingDisplay();
+  updateShopItem();
 }
 
 updateRingDisplay();
@@ -272,15 +313,32 @@ shopBackBtn.addEventListener('click', () => {
   updateRingDisplay();
 });
 
+if (refundBtn) {
+  refundBtn.addEventListener('click', () => {
+    refundPurchases();
+  });
+}
+
+if (resetGameBtn) {
+  resetGameBtn.addEventListener('click', () => {
+    resetGame();
+  });
+}
+
 if (buySlotItem) {
   buySlotItem.addEventListener('click', () => {
+    if (extraSkillSlots > 0) {
+      showShopMessage('Przedmiot już zakupiony');
+      return;
+    }
     if (ringCount >= 50) {
       ringCount -= 50;
       localStorage.setItem('ringCount', ringCount);
       updateRingDisplay();
       createBoosterSlot();
-      extraSkillSlots++;
+      extraSkillSlots = 1;
       localStorage.setItem('extraSkillSlots', extraSkillSlots);
+      updateShopItem();
     } else {
       showShopMessage('Brak środków!');
       updateRingDisplay();

--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -31,6 +31,7 @@
     <button id="boosterBtn" class="menu-button">Booster Mode</button>
     <button id="settingsBtn" class="menu-button">Ustawienia</button>
     <button id="shopBtn" class="menu-button">Shop</button>
+    <button id="resetGameBtn" class="menu-button">Zeruj grę</button>
   </div>
 
   <div id="settingsMenu" class="menu" style="display:none;">
@@ -57,6 +58,7 @@
       <input type="checkbox" id="toggleMusic" checked />
       Muzyka
     </label>
+    <button id="refundBtn" class="menu-button left-align">Zwrot zakupów</button>
     <button id="backBtn" class="menu-button">Wróć</button>
   </div>
 

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -74,6 +74,31 @@ body {
   color: #000;
 }
 
+.shop-item.purchased {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.shop-item.purchased::before,
+.shop-item.purchased::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 2px;
+  height: 100%;
+  background: red;
+}
+
+.shop-item.purchased::before {
+  transform: rotate(45deg);
+}
+
+.shop-item.purchased::after {
+  transform: rotate(-45deg);
+}
+
 .shop-item .ring-icon {
   width: 30px;
   height: 30px;
@@ -91,6 +116,11 @@ body {
   color: red;
   margin-top: 10px;
   display: none;
+}
+
+#settingsMenu .left-align {
+  margin-left: 0;
+  margin-right: auto;
 }
 
 #logo {


### PR DESCRIPTION
## Summary
- Show purchased shop items with a red X and disable further buys
- Add "Zwrot zakupów" in settings to refund purchases
- Add "Zeruj grę" in main menu to wipe rings and purchases

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a729c7e9ac832081a7faddc7db60c1