### PR TITLE
Move reset option into settings and left-align settings options

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -31,7 +31,6 @@
     <button id="boosterBtn" class="menu-button">Booster Mode</button>
     <button id="settingsBtn" class="menu-button">Ustawienia</button>
     <button id="shopBtn" class="menu-button">Shop</button>
-    <button id="resetGameBtn" class="menu-button">Zeruj grę</button>
   </div>
 
   <div id="settingsMenu" class="menu" style="display:none;">
@@ -58,7 +57,8 @@
       <input type="checkbox" id="toggleMusic" checked />
       Muzyka
     </label>
-    <button id="refundBtn" class="menu-button left-align">Zwrot zakupów</button>
+    <button id="resetGameBtn" class="menu-button">Zeruj grę</button>
+    <button id="refundBtn" class="menu-button">Zwrot zakupów</button>
     <button id="backBtn" class="menu-button">Wróć</button>
   </div>
 

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -55,6 +55,15 @@ body {
   background: rgba(255, 255, 255, 0.2);
 }
 
+#settingsMenu {
+  text-align: left;
+}
+
+#settingsMenu .menu-button {
+  margin-left: 0;
+  margin-right: auto;
+}
+
 #ringDisplay,
 #shopRingDisplay,
 .ring-display {
@@ -116,11 +125,6 @@ body {
   color: red;
   margin-top: 10px;
   display: none;
-}
-
-#settingsMenu .left-align {
-  margin-left: 0;
-  margin-right: auto;
 }
 
 #logo {


### PR DESCRIPTION
## Summary
- Move "Zeruj grę" button from main menu into settings panel.
- Align all settings menu options to the left for consistent layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72d90c8b883208929ddfe13dedd62