### PR TITLE
Highlight owned and selected character images

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -444,7 +444,15 @@ characterImg.src = `assets/${selectedCharacter}`;
 
 function updateCharacterImage() {
   characterImg.src = `assets/${selectedCharacter}`;
+  characterItems.forEach(item => {
+    if (item.dataset.character === selectedCharacter) {
+      item.classList.add('selected');
+    } else {
+      item.classList.remove('selected');
+    }
+  });
 }
+updateCharacterImage();
 
 const difficulties = {
   easy: { platformWidth: 90, speed: 1.5 },

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -148,11 +148,15 @@ body {
 
 .character-price {
   font-size: 14px;
-  color: #000;
+  color: #fff;
 }
 
 .character-item.owned {
-  border-color: gold;
+  border-color: yellow;
+}
+
+.character-item.selected {
+  border-color: red;
 }
 
 #logo {


### PR DESCRIPTION
## Summary
- Ensure shop prices are visible by styling character price text in white.
- Show yellow borders on purchased character images and red borders on the currently selected image.
- Update character image logic to toggle selection borders based on current choice.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a05f2c88320b13c9151d9f14096