### PR TITLE
Replace skill slot image with button and fix character proportions

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -66,8 +66,8 @@
     <h2>Sklep</h2>
     <div id="shopRingDisplay" class="ring-display"></div>
     <div id="buySlotItem" class="shop-item">
-      <div class="ring-icon"></div>
-      <span class="price">50</span>
+      <button>Dodatkowy slot</button>
+      <div class="price">50 obręczy</div>
     </div>
     <div id="characterShop" class="character-row">
       <div class="character-item" data-character="character.png">

--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -70,17 +70,22 @@ body {
   margin-bottom: 10px;
 }
 
+
 .shop-item {
-  width: 60px;
-  height: 60px;
   background: #fff;
   border: 2px solid #aaa;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   margin: 10px auto;
   cursor: pointer;
   color: #000;
+  padding: 10px;
+}
+
+.shop-item button {
+  width: 100%;
 }
 
 .shop-item.purchased {
@@ -108,17 +113,9 @@ body {
   transform: rotate(-45deg);
 }
 
-.shop-item .ring-icon {
-  width: 30px;
-  height: 30px;
-  border: 5px solid gold;
-  border-radius: 50%;
-  margin-right: 4px;
-  box-sizing: border-box;
-}
-
 .shop-item .price {
   font-size: 14px;
+  margin-top: 5px;
 }
 
 .shop-message {
@@ -142,7 +139,7 @@ body {
 
 .character-item img {
   width: 60px;
-  height: 60px;
+  height: auto;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- Preserve character image width while letting height scale automatically for correct aspect ratio.
- Replace skill slot's ring icon with a “Dodatkowy slot” button and display its price below in the shop.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73c4405c48320b74b014eeacb99d5