### PR TITLE
Refactor game code into ES modules with audio and storage separation

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -123,6 +123,6 @@
     <button id="newGameBtn">Nowa Gra</button>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.39/Tone.min.js"></script>
-  <script src="game.js"></script>
+  <script type="module" src="src/core.js"></script>
 </body>
 </html>

--- a/icy-tower/src/audio.js
+++ b/icy-tower/src/audio.js
@@ -1,0 +1,51 @@
+// Audio system using Tone.js
+// Handles music playback for the game
+
+const synth = new Tone.MonoSynth({
+  oscillator: { type: 'sawtooth' },
+  envelope: { attack: 0.02, decay: 0.1, sustain: 0.2, release: 0.4 }
+}).toDestination();
+
+const bassSynth = new Tone.MonoSynth({
+  oscillator: { type: 'square' },
+  filter: { type: 'lowpass', frequency: 200 },
+  envelope: { attack: 0.01, decay: 0.2, sustain: 0.3, release: 0.8 }
+}).toDestination();
+
+const kick = new Tone.MembraneSynth().toDestination();
+
+Tone.Transport.bpm.value = 160;
+
+const melody = [
+  'C4', 'E4', 'G4', 'B4', 'C5', 'B4', 'G4', 'E4',
+  'D4', 'F4', 'A4', 'C5', 'D5', 'A4', 'F4', 'D4'
+];
+
+const bassline = ['C2', 'C2', 'G1', 'C2', 'B1', 'G1', 'C2', 'G1'];
+
+const sequence = new Tone.Sequence((time, note) => {
+  synth.triggerAttackRelease(note, '16n', time);
+}, melody, '16n');
+
+const bassSequence = new Tone.Sequence((time, note) => {
+  bassSynth.triggerAttackRelease(note, '8n', time);
+  kick.triggerAttackRelease('C2', '8n', time);
+}, bassline, '8n');
+
+sequence.loop = true;
+bassSequence.loop = true;
+Tone.Transport.loop = true;
+Tone.Transport.loopEnd = '90s'; // roughly 1.5 minutes
+
+export function startMusic() {
+  Tone.start();
+  if (sequence.state !== 'started') {
+    sequence.start(0);
+    bassSequence.start(0);
+  }
+  Tone.Transport.start();
+}
+
+export function stopMusic() {
+  Tone.Transport.stop();
+}

--- a/icy-tower/src/store.js
+++ b/icy-tower/src/store.js
@@ -1,0 +1,14 @@
+// Simple wrapper around localStorage for JSON data
+export function load(key, defaultValue) {
+  const raw = localStorage.getItem(key);
+  if (raw === null) return defaultValue;
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    return defaultValue;
+  }
+}
+
+export function save(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
+}


### PR DESCRIPTION
## Summary
- migrate game entry to ES modules
- extract audio playback logic into dedicated module
- wrap localStorage access with a simple storage utility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a767902883208503cf1fbd8fb6a6