### PR TITLE
Fix menu buttons unresponsive due to sidebar overlay

### DIFF
--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -14,6 +14,7 @@ body {
   padding: 20px;
   background: rgba(0, 0, 0, 0.6);
   z-index: 100;
+  pointer-events: none;
 }
 
 #instructions {


### PR DESCRIPTION
## Summary
- Prevent side panels from intercepting clicks by disabling pointer events on instructions and scoreboard elements.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aa130ea08320b07648066c2964db