### PR TITLE
Handle missing Tone.js gracefully

### DIFF
--- a/icy-tower/src/audio.js
+++ b/icy-tower/src/audio.js
@@ -1,43 +1,53 @@
 // Audio system using Tone.js
 // Handles music playback for the game
 
-const synth = new Tone.MonoSynth({
-  oscillator: { type: 'sawtooth' },
-  envelope: { attack: 0.02, decay: 0.1, sustain: 0.2, release: 0.4 }
-}).toDestination();
+// Some environments (e.g. offline usage) might fail to load the Tone.js
+// library from the CDN.  If Tone isn't available we simply provide no-op
+// music functions so the rest of the game can still run.
+const hasTone = typeof Tone !== 'undefined';
 
-const bassSynth = new Tone.MonoSynth({
-  oscillator: { type: 'square' },
-  filter: { type: 'lowpass', frequency: 200 },
-  envelope: { attack: 0.01, decay: 0.2, sustain: 0.3, release: 0.8 }
-}).toDestination();
+let synth, bassSynth, kick, sequence, bassSequence;
 
-const kick = new Tone.MembraneSynth().toDestination();
+if (hasTone) {
+  synth = new Tone.MonoSynth({
+    oscillator: { type: 'sawtooth' },
+    envelope: { attack: 0.02, decay: 0.1, sustain: 0.2, release: 0.4 }
+  }).toDestination();
 
-Tone.Transport.bpm.value = 160;
+  bassSynth = new Tone.MonoSynth({
+    oscillator: { type: 'square' },
+    filter: { type: 'lowpass', frequency: 200 },
+    envelope: { attack: 0.01, decay: 0.2, sustain: 0.3, release: 0.8 }
+  }).toDestination();
 
-const melody = [
-  'C4', 'E4', 'G4', 'B4', 'C5', 'B4', 'G4', 'E4',
-  'D4', 'F4', 'A4', 'C5', 'D5', 'A4', 'F4', 'D4'
-];
+  kick = new Tone.MembraneSynth().toDestination();
 
-const bassline = ['C2', 'C2', 'G1', 'C2', 'B1', 'G1', 'C2', 'G1'];
+  Tone.Transport.bpm.value = 160;
 
-const sequence = new Tone.Sequence((time, note) => {
-  synth.triggerAttackRelease(note, '16n', time);
-}, melody, '16n');
+  const melody = [
+    'C4', 'E4', 'G4', 'B4', 'C5', 'B4', 'G4', 'E4',
+    'D4', 'F4', 'A4', 'C5', 'D5', 'A4', 'F4', 'D4'
+  ];
 
-const bassSequence = new Tone.Sequence((time, note) => {
-  bassSynth.triggerAttackRelease(note, '8n', time);
-  kick.triggerAttackRelease('C2', '8n', time);
-}, bassline, '8n');
+  const bassline = ['C2', 'C2', 'G1', 'C2', 'B1', 'G1', 'C2', 'G1'];
 
-sequence.loop = true;
-bassSequence.loop = true;
-Tone.Transport.loop = true;
-Tone.Transport.loopEnd = '90s'; // roughly 1.5 minutes
+  sequence = new Tone.Sequence((time, note) => {
+    synth.triggerAttackRelease(note, '16n', time);
+  }, melody, '16n');
+
+  bassSequence = new Tone.Sequence((time, note) => {
+    bassSynth.triggerAttackRelease(note, '8n', time);
+    kick.triggerAttackRelease('C2', '8n', time);
+  }, bassline, '8n');
+
+  sequence.loop = true;
+  bassSequence.loop = true;
+  Tone.Transport.loop = true;
+  Tone.Transport.loopEnd = '90s'; // roughly 1.5 minutes
+}
 
 export function startMusic() {
+  if (!hasTone) return;
   Tone.start();
   if (sequence.state !== 'started') {
     sequence.start(0);
@@ -47,5 +57,6 @@ export function startMusic() {
 }
 
 export function stopMusic() {
+  if (!hasTone) return;
   Tone.Transport.stop();
 }


### PR DESCRIPTION
## Summary
- Prevent game initialization from failing when Tone.js isn't loaded
- Provide no-op music start/stop functions if Tone.js is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8af500d748320b3cc7ff4e47e311e