### PR TITLE
Switch Icy Tower HTML to ES module entry point

### DIFF
--- a/icy-tower/index.html
+++ b/icy-tower/index.html
@@ -123,6 +123,6 @@
     <button id="newGameBtn">Nowa Gra</button>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.39/Tone.min.js"></script>
-  <script src="game.js"></script>
+  <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/icy-tower/main.js
+++ b/icy-tower/main.js
@@ -1,0 +1,1 @@
+import './game.js';


### PR DESCRIPTION
## Summary
- load the Icy Tower game via an ES module entry point
- add `main.js` that imports the existing `game.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b60f97188320bf9b48c87f6d5fa6