### PR TITLE
Connect new UI menu buttons to game start actions

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -443,15 +443,19 @@ function startGame() {
   requestAnimationFrame(loop);
 }
 
-arcadeBtn.addEventListener('click', () => {
+export function startArcade() {
   game.settings.continuousPlay = true;
   startGame();
-});
+}
 
-boosterBtn.addEventListener('click', () => {
+export function startBooster() {
   game.settings.continuousPlay = false;
   startGame();
-});
+}
+
+arcadeBtn.addEventListener('click', startArcade);
+
+boosterBtn.addEventListener('click', startBooster);
 
 document.addEventListener('keydown', e => {
   if (wheelOverlay.style.display !== 'none' && e.code === 'Space') {

--- a/src/ui/MenuRoot.tsx
+++ b/src/ui/MenuRoot.tsx
@@ -1,12 +1,13 @@
 import { FunctionalComponent, h } from 'preact';
+import { startArcade, startBooster } from '../../icy-tower/game.js';
 
 const handleClick = (label: string) => () => console.log(label);
 
 const MenuRoot: FunctionalComponent = () => (
   <div class="menu-root">
     <div class="central">
-      <button onClick={handleClick('button-1')}>Button 1</button>
-      <button onClick={handleClick('button-2')}>Button 2</button>
+      <button onClick={startArcade}>Arcade Mode</button>
+      <button onClick={startBooster}>Booster Mode</button>
       <button onClick={handleClick('button-3')}>Button 3</button>
     </div>
     <div class="corners">


### PR DESCRIPTION
## Summary
- export `startArcade` and `startBooster` from the game logic and reuse them for both menu variants
- import and call these functions from the Preact menu so new UI buttons start the game

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8d5cc0d8883208a8bbf319a359d8c