### PR TITLE
Add panel-based Preact menu with shop, settings and manual panels

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -125,6 +125,38 @@ useNewUi.addEventListener('change', () => {
   setNewUiEnabled(useNewUi.checked);
 });
 
+export function setWallBounceEnabled(v) {
+  game.settings.wallBounceEnabled = v;
+  save('wallBounceEnabled', game.settings.wallBounceEnabled);
+}
+
+export function getWallBounceEnabled() {
+  return game.settings.wallBounceEnabled;
+}
+
+export function setSpeedMultiplier(v) {
+  game.settings.speedMultiplier = Math.max(0.5, Math.min(3, v));
+  updateSpeedLabel();
+}
+
+export function getSpeedMultiplier() {
+  return game.settings.speedMultiplier;
+}
+
+export function setMusicEnabled(v) {
+  game.settings.musicEnabled = v;
+  save('musicEnabled', game.settings.musicEnabled);
+  if (game.settings.musicEnabled) {
+    startMusic();
+  } else {
+    stopMusic();
+  }
+}
+
+export function getMusicEnabled() {
+  return game.settings.musicEnabled;
+}
+
 function updateRingDisplay() {
   if (ringDisplay) ringDisplay.textContent = `Obręcze: ${ringCount}`;
   if (shopRingDisplay) shopRingDisplay.textContent = `Obręcze: ${ringCount}`;

--- a/src/ui/ManualPanel.tsx
+++ b/src/ui/ManualPanel.tsx
@@ -1,0 +1,9 @@
+import { FunctionalComponent, h } from 'preact';
+
+const ManualPanel: FunctionalComponent = () => (
+  <div class="manual-panel">
+    <p>Use arrow keys to move and space to jump. Reach as high as you can!</p>
+  </div>
+);
+
+export default ManualPanel;

--- a/src/ui/MenuRoot.tsx
+++ b/src/ui/MenuRoot.tsx
@@ -1,21 +1,40 @@
 import { FunctionalComponent, h } from 'preact';
+import { useState } from 'preact/hooks';
 import { startArcade, startBooster } from '../../icy-tower/game.js';
+import SettingsPanel from './SettingsPanel';
+import ManualPanel from './ManualPanel';
+import ShopPanel from './ShopPanel';
 
-const handleClick = (label: string) => () => console.log(label);
+const MenuRoot: FunctionalComponent = () => {
+  const [panel, setPanel] = useState<'main' | 'settings' | 'manual' | 'shop'>('main');
 
-const MenuRoot: FunctionalComponent = () => (
-  <div class="menu-root">
-    <div class="central">
-      <button onClick={startArcade}>Arcade Mode</button>
-      <button onClick={startBooster}>Booster Mode</button>
-      <button onClick={handleClick('button-3')}>Button 3</button>
+  return (
+    <div class="menu-root">
+      {panel === 'main' && (
+        <div class="central">
+          <button onClick={startBooster}>Booster Mode</button>
+          <button onClick={startArcade}>Arcade Mode</button>
+          <button onClick={() => setPanel('shop')}>Shop</button>
+        </div>
+      )}
+      {panel === 'settings' && <SettingsPanel />}
+      {panel === 'manual' && <ManualPanel />}
+      {panel === 'shop' && <ShopPanel />}
+      <div class="corners">
+        {panel !== 'main' && (
+          <button class="back" onClick={() => setPanel('main')}>
+            Back to Main
+          </button>
+        )}
+        <button class="settings" onClick={() => setPanel('settings')}>
+          Settings
+        </button>
+        <button class="manual" onClick={() => setPanel('manual')}>
+          Manual
+        </button>
+      </div>
     </div>
-    <div class="corners">
-      <button class="back" onClick={handleClick('Back')}>Back</button>
-      <button class="settings" onClick={handleClick('Settings')}>Settings</button>
-      <button class="manual" onClick={handleClick('Manual')}>Manual</button>
-    </div>
-  </div>
-);
+  );
+};
 
 export default MenuRoot;

--- a/src/ui/SettingsPanel.tsx
+++ b/src/ui/SettingsPanel.tsx
@@ -1,0 +1,64 @@
+import { FunctionalComponent, h } from 'preact';
+import { useState } from 'preact/hooks';
+import {
+  getWallBounceEnabled,
+  setWallBounceEnabled,
+  getSpeedMultiplier,
+  setSpeedMultiplier,
+  getMusicEnabled,
+  setMusicEnabled
+} from '../../icy-tower/game.js';
+
+const SettingsPanel: FunctionalComponent = () => {
+  const [wallBounce, setWallBounce] = useState(getWallBounceEnabled());
+  const [speed, setSpeed] = useState(getSpeedMultiplier());
+  const [music, setMusic] = useState(getMusicEnabled());
+
+  const decreaseSpeed = () => {
+    const v = Math.max(0.5, speed - 0.5);
+    setSpeed(v);
+    setSpeedMultiplier(v);
+  };
+
+  const increaseSpeed = () => {
+    const v = Math.min(3, speed + 0.5);
+    setSpeed(v);
+    setSpeedMultiplier(v);
+  };
+
+  return (
+    <div class="settings-panel">
+      <label>
+        <input
+          type="checkbox"
+          checked={wallBounce}
+          onChange={e => {
+            const v = (e.target as HTMLInputElement).checked;
+            setWallBounce(v);
+            setWallBounceEnabled(v);
+          }}
+        />
+        Wall bounce
+      </label>
+      <div class="speed-control">
+        <button onClick={decreaseSpeed}>-</button>
+        <span>{speed.toFixed(1)}x</span>
+        <button onClick={increaseSpeed}>+</button>
+      </div>
+      <label>
+        <input
+          type="checkbox"
+          checked={music}
+          onChange={e => {
+            const v = (e.target as HTMLInputElement).checked;
+            setMusic(v);
+            setMusicEnabled(v);
+          }}
+        />
+        Music
+      </label>
+    </div>
+  );
+};
+
+export default SettingsPanel;

--- a/src/ui/ShopPanel.tsx
+++ b/src/ui/ShopPanel.tsx
@@ -1,0 +1,71 @@
+import { FunctionalComponent, h } from 'preact';
+import { useState } from 'preact/hooks';
+import { load, save } from '../../icy-tower/store.js';
+
+const characters = ['character.png', 'character2.png', 'character3.png', 'character4.png'];
+
+const ShopPanel: FunctionalComponent = () => {
+  const [ringCount, setRingCount] = useState(load('ringCount', 0));
+  const [extraSkillSlots, setExtraSkillSlots] = useState(load('extraSkillSlots', 0));
+  const [purchasedCharacters, setPurchasedCharacters] = useState<string[]>(
+    load('purchasedCharacters', ['character.png'])
+  );
+  const [selectedCharacter, setSelectedCharacter] = useState(load('selectedCharacter', 'character.png'));
+
+  const spend = (amount: number) => {
+    const newCount = ringCount - amount;
+    setRingCount(newCount);
+    save('ringCount', newCount);
+  };
+
+  const buySlot = () => {
+    if (extraSkillSlots > 0 || ringCount < 50) return;
+    spend(50);
+    setExtraSkillSlots(extraSkillSlots + 1);
+    save('extraSkillSlots', extraSkillSlots + 1);
+  };
+
+  const buyOrSelectCharacter = (c: string) => {
+    if (purchasedCharacters.includes(c)) {
+      setSelectedCharacter(c);
+      save('selectedCharacter', c);
+    } else if (ringCount >= 50) {
+      spend(50);
+      const newChars = [...purchasedCharacters, c];
+      setPurchasedCharacters(newChars);
+      save('purchasedCharacters', newChars);
+      setSelectedCharacter(c);
+      save('selectedCharacter', c);
+    }
+  };
+
+  return (
+    <div class="shop-panel">
+      <div class="ring-display">Rings: {ringCount}</div>
+      <div class="shop-item">
+        <button disabled={extraSkillSlots > 0 || ringCount < 50} onClick={buySlot}>
+          Buy extra slot (50 rings)
+        </button>
+        {extraSkillSlots > 0 && <span class="owned">Purchased</span>}
+      </div>
+      <div class="character-row">
+        {characters.map(c => {
+          const owned = purchasedCharacters.includes(c);
+          const selected = selectedCharacter === c;
+          return (
+            <div
+              key={c}
+              class={`character-item${owned ? ' owned' : ''}${selected ? ' selected' : ''}`}
+              onClick={() => buyOrSelectCharacter(c)}
+            >
+              <img src={`assets/${c}`} alt={c} />
+              {!owned && <div class="price">50</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ShopPanel;

--- a/src/ui/menu.css
+++ b/src/ui/menu.css
@@ -20,16 +20,21 @@
 }
 
 .corners .back {
-  top: 1rem;
+  bottom: 1rem;
   left: 1rem;
 }
 
 .corners .settings {
-  top: 1rem;
-  right: 1rem;
+  bottom: 1rem;
+  right: 5rem;
 }
 
 .corners .manual {
   bottom: 1rem;
   right: 1rem;
+}
+
+.central button {
+  font-size: 2rem;
+  padding: 1rem 2rem;
 }


### PR DESCRIPTION
## Summary
- Expose setters in game logic for wall bounce, speed and music
- Implement SettingsPanel, ManualPanel and ShopPanel with store persistence
- Replace MenuRoot with panel navigation and update menu layout
- Style menu buttons and corners for new layout

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8d7c11c7c8320a21452f8bc46282b