### PR TITLE
Fix menu initialization syntax error

### DIFF
--- a/icy-tower/main.js
+++ b/icy-tower/main.js
@@ -4,6 +4,9 @@ import { isNewUiEnabled } from './store.js';
 if (isNewUiEnabled()) {
   const root = document.getElementById('ui-root');
   root.style.display = 'block';
-  document.getElementById('mainMenu')?.style.display = 'none';
+  const mainMenu = document.getElementById('mainMenu');
+  if (mainMenu) {
+    mainMenu.style.display = 'none';
+  }
   import('../src/ui/bootstrapPreact').then(m => m.mount());
 }


### PR DESCRIPTION
## Summary
- Replace invalid optional chaining assignment when hiding old menu
- Allow new UI module to mount correctly without breaking script

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e079ca288320ae1fdaea732e68b6