### PR TITLE
fix: ensure menu overlays scoreboard

### DIFF
--- a/icy-tower/styles.css
+++ b/icy-tower/styles.css
@@ -34,7 +34,7 @@ body {
   padding: 40px;
   border-radius: 10px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
-  z-index: 50;
+  z-index: 200;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- raise `.menu` z-index so the main menu displays above the scoreboard and instructions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8e403a8148320b3261ca2be8f9c60