### PR TITLE
Connect new UI toggle to settings checkbox

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -121,8 +121,26 @@ toggleMusic.addEventListener('change', () => {
     stopMusic();
   }
 });
-useNewUi.addEventListener('change', () => {
-  setNewUiEnabled(useNewUi.checked);
+useNewUi.addEventListener('change', async () => {
+  const enabled = useNewUi.checked;
+  setNewUiEnabled(enabled);
+  const root = document.getElementById('ui-root');
+  const mainMenu = document.getElementById('mainMenu');
+  const settingsMenu = document.getElementById('settingsMenu');
+  if (enabled) {
+    if (root) root.style.display = 'block';
+    if (mainMenu) mainMenu.style.display = 'none';
+    if (settingsMenu) settingsMenu.style.display = 'none';
+    const m = await import('../src/ui/bootstrapPreact');
+    m.mount();
+  } else {
+    if (root) {
+      root.style.display = 'none';
+      root.innerHTML = '';
+    }
+    if (settingsMenu) settingsMenu.style.display = 'none';
+    if (mainMenu) mainMenu.style.display = 'block';
+  }
 });
 
 export function setWallBounceEnabled(v) {


### PR DESCRIPTION
## Summary
- Mount Preact UI when "Use new UI" is toggled on
- Hide legacy menus and show old UI when toggle is switched off

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e8c7a11083209c7c860879b2d8d4