### PR TITLE
Add error fallback for new UI loading

### DIFF
--- a/icy-tower/game.js
+++ b/icy-tower/game.js
@@ -131,8 +131,20 @@ useNewUi.addEventListener('change', async () => {
     if (root) root.style.display = 'block';
     if (mainMenu) mainMenu.style.display = 'none';
     if (settingsMenu) settingsMenu.style.display = 'none';
-    const m = await import('../src/ui/bootstrapPreact');
-    m.mount();
+    try {
+      const m = await import('../src/ui/bootstrapPreact');
+      m.mount();
+    } catch (err) {
+      console.error(err);
+      if (mainMenu) mainMenu.style.display = 'block';
+      if (root) {
+        root.style.display = 'none';
+        root.innerHTML = '';
+      }
+      if (settingsMenu) settingsMenu.style.display = 'none';
+      useNewUi.checked = false;
+      setNewUiEnabled(false);
+    }
   } else {
     if (root) {
       root.style.display = 'none';

--- a/icy-tower/main.js
+++ b/icy-tower/main.js
@@ -1,5 +1,5 @@
 import './game.js';
-import { isNewUiEnabled } from './store.js';
+import { isNewUiEnabled, setNewUiEnabled } from './store.js';
 
 if (isNewUiEnabled()) {
   const root = document.getElementById('ui-root');
@@ -8,5 +8,17 @@ if (isNewUiEnabled()) {
   if (mainMenu) {
     mainMenu.style.display = 'none';
   }
-  import('../src/ui/bootstrapPreact').then(m => m.mount());
+  import('../src/ui/bootstrapPreact')
+    .then(m => m.mount())
+    .catch(err => {
+      console.error(err);
+      if (mainMenu) mainMenu.style.display = 'block';
+      if (root) {
+        root.style.display = 'none';
+        root.innerHTML = '';
+      }
+      const useNewUi = document.getElementById('useNewUi');
+      if (useNewUi) useNewUi.checked = false;
+      setNewUiEnabled(false);
+    });
 }


### PR DESCRIPTION
## Summary
- wrap dynamic new UI imports in try/catch blocks
- restore classic UI and log errors on failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8eb29f5b88320bc3cb385e078dab8